### PR TITLE
fix: IOS build error due to flutter_nfc_kit issue fixes.

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end


### PR DESCRIPTION
- **Fixed issue**: https://github.com/fossasia/magic-epaper-app/issues/24
- Resolved build error related to flutter_nfc_kit plugin requiring iOS 13.0+
- Created and configured Podfile with minimum deployment target to iOS 13.0
- Ensured compatibility with plugin requirements and successful iOS build


**Here is the ios build preview:** 
![image](https://github.com/user-attachments/assets/5266520a-4329-48e6-899e-83b91c13c893)

## Summary by Sourcery

Configure iOS deployment target to resolve build issues with flutter_nfc_kit plugin

Bug Fixes:
- Resolved iOS build error by setting minimum deployment target to iOS 13.0 for flutter_nfc_kit plugin compatibility

Build:
- Created Podfile with platform specification for iOS 13.0 to ensure proper build configuration