### PR TITLE
fix: movable background issue

### DIFF
--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -10,6 +10,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/bottom_bar.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/text_bottom_bar.dart';
+import 'package:pro_image_editor/core/models/layers/layer_interaction.dart';
 import 'package:pro_image_editor/designs/whatsapp/whatsapp_paint_colorpicker.dart';
 import 'package:pro_image_editor/designs/whatsapp/whatsapp_text_colorpicker.dart';
 import 'package:pro_image_editor/designs/whatsapp/whatsapp_text_size_slider.dart';
@@ -235,6 +236,13 @@ class _MovableBackgroundImageExampleState
     editorKey.currentState?.replaceLayer(
       index: 0, // Replace first layer (canvas)
       layer: WidgetLayer(
+        interaction: LayerInteraction(
+          enableEdit: false,
+          enableMove: false,
+          enableRotate: false,
+          enableScale: false,
+          enableSelection: false,
+        ),
         offset: Offset.zero,
         scale: _initScale,
         widget: Image.asset(


### PR DESCRIPTION
Fixes [#33](https://github.com/fossasia/magic-epaper-app/issues/33) – Resolved an issue where the background image could be unintentionally moved while editing. The update ensures the background stays fixed, allowing only the foreground elements (like drawings or overlays) to be interactive and draggable.

## Summary by Sourcery

Disable all interactive operations on the background layer to prevent unintentional movement and ensure only foreground elements remain draggable.

Bug Fixes:
- Prevent background image from being moved, edited, rotated, scaled, or selected during editing.

Enhancements:
- Introduce LayerInteraction model to explicitly configure and disable interactions on the background layer.