### PR TITLE
fix: create color palette based on display's supported colors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/provider/getitlocator.dart';
 import 'package:magic_epaper_app/provider/image_loader.dart';
-import 'package:magic_epaper_app/provider/color_palette_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:magic_epaper_app/view/display_selection_screen.dart';
 
@@ -9,8 +8,6 @@ void main() {
   setupLocator();
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (context) => ImageLoader()),
-    ChangeNotifierProvider<ColorPaletteProvider>(
-        create: (context) => getIt<ColorPaletteProvider>()),
   ], child: const MyApp()));
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:magic_epaper_app/provider/getitlocator.dart';
 import 'package:magic_epaper_app/provider/image_loader.dart';
 import 'package:magic_epaper_app/provider/color_palette_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:magic_epaper_app/view/display_selection_screen.dart';
 
 void main() {
+  setupLocator();
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (context) => ImageLoader()),
-    ChangeNotifierProvider(create: (context) => ColorPaletteProvider()),
+    ChangeNotifierProvider<ColorPaletteProvider>(
+        create: (context) => getIt<ColorPaletteProvider>()),
   ], child: const MyApp()));
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/provider/image_loader.dart';
+import 'package:magic_epaper_app/provider/color_palette_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:magic_epaper_app/view/display_selection_screen.dart';
 
 void main() {
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (context) => ImageLoader()),
+    ChangeNotifierProvider(create: (context) => ColorPaletteProvider()),
   ], child: const MyApp()));
 }
 

--- a/lib/pro_image_editor/features/bottom_bar.dart
+++ b/lib/pro_image_editor/features/bottom_bar.dart
@@ -33,7 +33,6 @@ class BottomBarCustom extends StatefulWidget {
     required this.configs,
     required this.strokeWidth,
     required this.onSetLineWidth,
-    required this.initColor,
     required this.onColorChanged,
     this.iconStrokeWidthThin = ProImageEditorIcons.penSize1,
     this.iconStrokeWidthMedium = ProImageEditorIcons.penSize2,
@@ -62,7 +61,7 @@ class BottomBarCustom extends StatefulWidget {
   ///
   /// This color sets the initial paint color, providing a starting point
   /// for color customization.
-  final Color initColor;
+  final Color initColor = Colors.black;
 
   /// Callback function for handling color changes.
   ///

--- a/lib/pro_image_editor/features/bottom_bar.dart
+++ b/lib/pro_image_editor/features/bottom_bar.dart
@@ -135,7 +135,6 @@ class _BottomBarCustomState extends State<BottomBarCustom> {
                     ? Expanded(
                         child: ColorPickerCustom(
                           onColorChanged: widget.onColorChanged,
-                          initColor: widget.initColor,
                         ),
                       )
                     : _buildLineWidths(),

--- a/lib/pro_image_editor/features/color_picker.dart
+++ b/lib/pro_image_editor/features/color_picker.dart
@@ -25,7 +25,6 @@ class ColorPickerCustom extends StatefulWidget {
   const ColorPickerCustom({
     super.key,
     required this.onColorChanged,
-    required this.initColor,
   });
 
   /// Callback for handling color changes.
@@ -38,20 +37,21 @@ class ColorPickerCustom extends StatefulWidget {
   ///
   /// This color sets the initial value of the picker, providing a starting
   /// point for color selection.
-  final Color initColor;
+  final Color initColor = Colors.black;
 
   @override
   State<ColorPickerCustom> createState() => _ColorPickerCustomState();
 }
 
 class _ColorPickerCustomState extends State<ColorPickerCustom> {
-  Color _selectedColor = Colors.black;
+  late Color _selectedColor;
   List<Color> _colors = [];
 
   @override
   void initState() {
     super.initState();
-    widget.onColorChanged(_selectedColor);
+    // Initialize the selected color with the initial color from the widget.
+    _selectedColor = widget.initColor;
   }
 
   @override

--- a/lib/pro_image_editor/features/color_picker.dart
+++ b/lib/pro_image_editor/features/color_picker.dart
@@ -50,7 +50,6 @@ class _ColorPickerCustomState extends State<ColorPickerCustom> {
   @override
   void initState() {
     super.initState();
-    // Initialize the selected color with the initial color from the widget.
     _selectedColor = widget.initColor;
   }
 

--- a/lib/pro_image_editor/features/color_picker.dart
+++ b/lib/pro_image_editor/features/color_picker.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:magic_epaper_app/provider/color_palette_provider.dart';
+import 'package:provider/provider.dart';
 
 /// A stateful widget that provides a color picker inspired by WhatsApp.
 ///
@@ -37,21 +37,14 @@ class ColorPickerCustom extends StatefulWidget {
   ///
   /// This color sets the initial value of the picker, providing a starting
   /// point for color selection.
-  final Color initColor = Colors.black;
 
   @override
   State<ColorPickerCustom> createState() => _ColorPickerCustomState();
 }
 
 class _ColorPickerCustomState extends State<ColorPickerCustom> {
-  late Color _selectedColor;
+  Color _selectedColor = Colors.black;
   List<Color> _colors = [];
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedColor = widget.initColor;
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -64,10 +57,8 @@ class _ColorPickerCustomState extends State<ColorPickerCustom> {
       itemBuilder: (context, index) {
         Color color = _colors[index];
         bool selected = _selectedColor == color;
-
         double size = !selected ? 20 : 24;
         double borderWidth = !selected ? 2.5 : 4;
-
         return Center(
           child: GestureDetector(
             onTap: () {

--- a/lib/pro_image_editor/features/color_picker.dart
+++ b/lib/pro_image_editor/features/color_picker.dart
@@ -1,7 +1,7 @@
 // Flutter imports:
 import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/provider/color_palette_provider.dart';
-import 'package:provider/provider.dart';
+import 'package:magic_epaper_app/provider/getitlocator.dart';
 
 /// A stateful widget that provides a color picker inspired by WhatsApp.
 ///
@@ -44,11 +44,10 @@ class ColorPickerCustom extends StatefulWidget {
 
 class _ColorPickerCustomState extends State<ColorPickerCustom> {
   Color _selectedColor = Colors.black;
-  List<Color> _colors = [];
+  final List<Color> _colors = getIt<ColorPaletteProvider>().colors;
 
   @override
   Widget build(BuildContext context) {
-    _colors = context.watch<ColorPaletteProvider>().colors;
     return ListView.builder(
       padding: const EdgeInsets.symmetric(horizontal: 14),
       scrollDirection: Axis.horizontal,

--- a/lib/pro_image_editor/features/color_picker.dart
+++ b/lib/pro_image_editor/features/color_picker.dart
@@ -1,5 +1,7 @@
 // Flutter imports:
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:magic_epaper_app/provider/color_palette_provider.dart';
 
 /// A stateful widget that provides a color picker inspired by WhatsApp.
 ///
@@ -44,21 +46,17 @@ class ColorPickerCustom extends StatefulWidget {
 
 class _ColorPickerCustomState extends State<ColorPickerCustom> {
   Color _selectedColor = Colors.black;
-
-  final List<Color> _colors = [
-    Colors.white,
-    Colors.black,
-    Colors.red,
-  ];
+  List<Color> _colors = [];
 
   @override
   void initState() {
     super.initState();
-    _selectedColor = widget.initColor;
+    widget.onColorChanged(_selectedColor);
   }
 
   @override
   Widget build(BuildContext context) {
+    _colors = context.watch<ColorPaletteProvider>().colors;
     return ListView.builder(
       padding: const EdgeInsets.symmetric(horizontal: 14),
       scrollDirection: Axis.horizontal,

--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -586,7 +586,6 @@ List<ReactiveWidget> _buildPaintEditorBody(
       builder: (_) => BottomBarCustom(
         configs: paintEditor.configs,
         strokeWidth: paintEditor.paintCtrl.strokeWidth,
-        initColor: paintEditor.paintCtrl.color,
         onColorChanged: (color) {
           paintEditor.paintCtrl.setColor(color);
           paintEditor.uiPickerStream.add(null);

--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -439,6 +439,7 @@ class _MovableBackgroundImageExampleState
                 bodyItems: _buildPaintEditorBody,
               ),
               style: const PaintEditorStyle(
+                initialColor: Colors.black,
                 uiOverlayStyle: SystemUiOverlayStyle(
                   statusBarColor: Colors.black,
                 ),

--- a/lib/pro_image_editor/features/text_bottom_bar.dart
+++ b/lib/pro_image_editor/features/text_bottom_bar.dart
@@ -124,7 +124,6 @@ class _TextBottomBarState extends State<TextBottomBar> {
                     ? Expanded(
                         child: ColorPickerCustom(
                           onColorChanged: widget.onColorChanged,
-                          initColor: widget.initColor,
                         ),
                       )
                     : Expanded(

--- a/lib/provider/color_palette_provider.dart
+++ b/lib/provider/color_palette_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ColorPaletteProvider extends ChangeNotifier {
+  List<Color> _colors = [];
+
+  List<Color> get colors => _colors;
+
+  void updateColors(List<Color> newColors) {
+    _colors = newColors;
+    notifyListeners();
+  }
+}

--- a/lib/provider/getitlocator.dart
+++ b/lib/provider/getitlocator.dart
@@ -1,0 +1,9 @@
+import 'package:get_it/get_it.dart';
+import 'package:magic_epaper_app/provider/color_palette_provider.dart';
+
+final GetIt getIt = GetIt.instance;
+
+void setupLocator() {
+  getIt.registerLazySingleton<ColorPaletteProvider>(
+      () => ColorPaletteProvider());
+}

--- a/lib/view/display_selection_screen.dart
+++ b/lib/view/display_selection_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/constants.dart';
+import 'package:magic_epaper_app/provider/getitlocator.dart';
 import 'package:magic_epaper_app/util/epd/epd.dart';
 import 'package:magic_epaper_app/util/epd/gdey037z03.dart';
 import 'package:magic_epaper_app/util/epd/gdey037z03bw.dart';
@@ -21,60 +22,65 @@ class _DisplaySelectionScreenState extends State<DisplaySelectionScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: AppBar(
-        backgroundColor: colorAccent,
-        elevation: 0,
-        title: const Padding(
-          padding: EdgeInsets.fromLTRB(5, 16, 16, 5),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Magic ePaper',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                  )),
-              SizedBox(height: 8),
-              Text('Select your ePaper display type',
-                  style: TextStyle(
-                    fontSize: 16,
-                    color: Colors.white,
-                  )),
-            ],
-          ),
-        ),
-        toolbarHeight: 85,
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(10.0, 14, 16.0, 16.0),
-          child: Column(
-            children: [
-              Expanded(
-                child: GridView.builder(
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    childAspectRatio: 0.6,
-                    mainAxisSpacing: 8,
-                    crossAxisSpacing: 8,
-                  ),
-                  itemCount: displays.length,
-                  itemBuilder: (context, index) => DisplayCard(
-                    display: displays[index],
-                    isSelected: selectedIndex == index,
-                    onTap: () => setState(() => selectedIndex = index),
-                  ),
+    return ChangeNotifierProvider<ColorPaletteProvider>(
+        create: (_) => getIt<ColorPaletteProvider>(),
+        builder: (context, child) {
+          return Scaffold(
+            backgroundColor: Colors.white,
+            appBar: AppBar(
+              backgroundColor: colorAccent,
+              elevation: 0,
+              title: const Padding(
+                padding: EdgeInsets.fromLTRB(5, 16, 16, 5),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Magic ePaper',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        )),
+                    SizedBox(height: 8),
+                    Text('Select your ePaper display type',
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: Colors.white,
+                        )),
+                  ],
                 ),
               ),
-              _buildContinueButton(context),
-            ],
-          ),
-        ),
-      ),
-    );
+              toolbarHeight: 85,
+            ),
+            body: SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(10.0, 14, 16.0, 16.0),
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: GridView.builder(
+                        gridDelegate:
+                            const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 2,
+                          childAspectRatio: 0.6,
+                          mainAxisSpacing: 8,
+                          crossAxisSpacing: 8,
+                        ),
+                        itemCount: displays.length,
+                        itemBuilder: (context, index) => DisplayCard(
+                          display: displays[index],
+                          isSelected: selectedIndex == index,
+                          onTap: () => setState(() => selectedIndex = index),
+                        ),
+                      ),
+                    ),
+                    _buildContinueButton(context),
+                  ],
+                ),
+              ),
+            ),
+          );
+        });
   }
 
   Widget _buildContinueButton(BuildContext context) {

--- a/lib/view/display_selection_screen.dart
+++ b/lib/view/display_selection_screen.dart
@@ -4,6 +4,8 @@ import 'package:magic_epaper_app/util/epd/epd.dart';
 import 'package:magic_epaper_app/util/epd/gdey037z03.dart';
 import 'package:magic_epaper_app/util/epd/gdey037z03bw.dart';
 import 'package:magic_epaper_app/view/image_editor.dart';
+import 'package:provider/provider.dart';
+import 'package:magic_epaper_app/provider/color_palette_provider.dart';
 import 'package:magic_epaper_app/view/widget/display_card.dart';
 
 class DisplaySelectionScreen extends StatefulWidget {
@@ -83,6 +85,10 @@ class _DisplaySelectionScreenState extends State<DisplaySelectionScreen> {
       child: ElevatedButton(
         onPressed: isEnabled
             ? () {
+                context.read<ColorPaletteProvider>().updateColors(
+                      displays[selectedIndex].colors,
+                    );
+
                 Navigator.push(
                   context,
                   MaterialPageRoute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   mime: ^2.0.0
   intl: ^0.19.0
   path_provider: ^2.0.15
+  get_it: ^8.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes #38 

Screen Recording:

https://github.com/user-attachments/assets/f2e9bd84-8752-4d9a-bbb4-ff4425312b9e


- Used a provider to use the palette displayed in the epd class
- changed initialisation color for painting from red to black

## Summary by Sourcery

Introduce and wire up ColorPaletteProvider to dynamically feed display-specific color palettes into the color picker and default the initial paint color to black.

New Features:
- Introduce ColorPaletteProvider to manage and update the active color palette based on the selected display.

Bug Fixes:
- Change the default initial paint color from red to black across editors.

Enhancements:
- Wire up DisplaySelectionScreen to populate the provider with the chosen e-paper display’s supported colors.
- Refactor ColorPickerCustom and BottomBarCustom to consume the dynamic palette from the provider and remove hard-coded initialColor parameters.
- Register ColorPaletteProvider in the app’s MultiProvider setup.