### PR TITLE
fix: navigation issue closing editor redirects to start screen.

### DIFF
--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -10,6 +10,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/bottom_bar.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/text_bottom_bar.dart';
+import 'package:pro_image_editor/core/models/layers/layer_interaction.dart';
 import 'package:pro_image_editor/designs/whatsapp/whatsapp_paint_colorpicker.dart';
 import 'package:pro_image_editor/designs/whatsapp/whatsapp_text_colorpicker.dart';
 import 'package:pro_image_editor/designs/whatsapp/whatsapp_text_size_slider.dart';
@@ -235,6 +236,13 @@ class _MovableBackgroundImageExampleState
     editorKey.currentState?.replaceLayer(
       index: 0, // Replace first layer (canvas)
       layer: WidgetLayer(
+        interaction: LayerInteraction(
+          enableEdit: false,
+          enableMove: false,
+          enableRotate: false,
+          enableScale: false,
+          enableSelection: false,
+        ),
         offset: Offset.zero,
         scale: _initScale,
         widget: Image.asset(

--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -332,10 +332,6 @@ class _MovableBackgroundImageExampleState
             onImageEditingComplete: (Uint8List bytes) async {
               Navigator.pop(context, bytes);
             },
-            onCloseEditor: (editorMode) {
-              // Handle normal close without editing completion
-              Navigator.of(context).pop();
-            },
             mainEditorCallbacks: MainEditorCallbacks(
               helperLines: HelperLinesCallbacks(onLineHit: vibrateLineHit),
               onAfterViewInit: () {


### PR DESCRIPTION
Fixes [#34](https://github.com/fossasia/magic-epaper-app/issues/34) – Editor Screen exit now returns to the previous screen.
Previously, it always redirected to the Start Screen, breaking navigation flow.

**previous behaviour**: closing editor redirects to start screen everytime, breaking navigation flow.

https://github.com/user-attachments/assets/f232793b-32a9-4ffa-8781-d5293daa3e5c



**updated behaviour**:  closing editor returns to the previous screen only. 

https://github.com/user-attachments/assets/4cafe35a-5def-4a25-a0be-74da871bafad


