### PR TITLE
fix: Optimized RemapQuantizer

### DIFF
--- a/lib/util/image_processing/remap_quantizer.dart
+++ b/lib/util/image_processing/remap_quantizer.dart
@@ -7,9 +7,9 @@ class RemapQuantizer extends img.Quantizer {
 
   final List<img.Color> _colorLut = [];
 
-  late final Int32List _paletteR;
-  late final Int32List _paletteG;
-  late final Int32List _paletteB;
+  late final Uint8List _paletteR;
+  late final Uint8List _paletteG;
+  late final Uint8List _paletteB;
 
   final Map<int, int> _colorCache = {};
   static const int _maxCacheSize = 1024;
@@ -17,9 +17,9 @@ class RemapQuantizer extends img.Quantizer {
   RemapQuantizer({required this.palette}) {
     final numColors = palette.numColors;
 
-    _paletteR = Int32List(numColors);
-    _paletteG = Int32List(numColors);
-    _paletteB = Int32List(numColors);
+    _paletteR = Uint8List(numColors);
+    _paletteG = Uint8List(numColors);
+    _paletteB = Uint8List(numColors);
 
     for (int i = 0; i < numColors; i++) {
       final r = palette.getRed(i) as int;
@@ -50,7 +50,7 @@ class RemapQuantizer extends img.Quantizer {
   }
 
   int _getColorIndexInternal(int r, int g, int b) {
-    final cacheKey = (r << 16) | (g << 8) | b;
+    final cacheKey = ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0xFF);
 
     final cachedResult = _colorCache[cacheKey];
     if (cachedResult != null) {


### PR DESCRIPTION
Fixes #37 

Optimizations:

- Pre-allocated typed arrays: Use `Int32List ` for palette RGB values instead of repeated method calls
- Eliminated temporary arrays: Removed distance array creation in `_map()` method
- Reduced object allocation: Direct RGB access without creating intermediate Color objects
- Early termination: Exit immediately on exact color matches (distance = 0)
- Inline distance calculation: Performs square distance calculations faster
- LRU-style color cache: Cache recently computed color mappings using bit-shift hashing, since neighboring pixels in dithering often map to same colors

Real world Performance :
Noticed about 0.5 to 0.75 seconds improvement compared to the older algorithm on a low specification phone

## Summary by Sourcery

Optimize RemapQuantizer to accelerate palette lookup and reduce memory churn.

Enhancements:
- Preallocate Int32List arrays for palette red, green, and blue values to avoid repeated getter calls
- Inline squared distance computation and remove temporary distance arrays for faster nearest‐neighbor search
- Introduce an LRU‐style cache keyed by packed RGB to reuse recent color mappings with lightweight eviction
- Short‐circuit palette search on exact matches for immediate results