### PR TITLE
feat: added unsigned android build apk workflow.

### DIFF
--- a/.github/actions/android/unsigned/action.yml
+++ b/.github/actions/android/unsigned/action.yml
@@ -1,0 +1,71 @@
+name: "Unsigned Android Build Workflow"
+
+description: "Build unsigned APK and push to apk-unsigned branch"
+
+inputs:
+  VERSION_NAME:
+    description: "Version name from common build"
+    required: true
+  VERSION_CODE:
+    description: "Version code from common build"
+    required: true
+  GITHUB_TOKEN:
+    description: "GitHub token passed from workflow"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version-file: pubspec.yaml
+        cache: true
+
+    - name: Fetch Dependencies
+      shell: bash
+      run: flutter pub get
+
+    - name: Build Unsigned APK
+      shell: bash
+      run: |
+        flutter build apk --release --build-name ${{ inputs.VERSION_NAME }} --build-number ${{ inputs.VERSION_CODE }}
+        if [ ! -f build/app/outputs/flutter-apk/app-release.apk ]; then
+          echo "Unsigned APK not found. Build might have failed."
+          exit 1
+        fi
+
+    - name: Clone or Init apk-unsigned Branch
+      shell: bash
+      run: |
+        git clone https://x-access-token:${{ inputs.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git apk-temp
+        cd apk-temp
+        if git ls-remote --exit-code --heads origin apk-unsigned; then
+          git checkout apk-unsigned
+        else
+          git checkout --orphan apk-unsigned
+          git rm -rf . || true
+        fi
+
+    - name: Store Unsigned APK
+      shell: bash
+      run: |
+        cp build/app/outputs/flutter-apk/app-release.apk apk-temp/unsigned.apk
+
+    - name: Commit & Push Unsigned APK
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      run: |
+        cd apk-temp
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add unsigned.apk
+        git commit -m "[Unsigned APK] Update for v${{ inputs.VERSION_NAME }} (#${{ inputs.VERSION_CODE }})" || echo "Nothing to commit"
+        git push -u origin apk-unsigned
+
+    - name: Upload Unsigned APK as Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: unsigned-apk
+        path: build/app/outputs/flutter-apk/app-release.apk

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,6 +67,21 @@ jobs:
           git branch -m version
           git push --force origin version
 
+  unsigned:
+    name: Unsigned Android Build
+    needs: common
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Main
+        uses: actions/checkout@v4
+
+      - name: Unsigned APK Workflow
+        uses: ./.github/actions/android/unsigned
+        with:
+          VERSION_NAME: ${{ needs.common.outputs.VERSION_NAME }}
+          VERSION_CODE: ${{ needs.common.outputs.VERSION_CODE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   android:
     name: Android Flutter Build
     needs: common


### PR DESCRIPTION
Fixes #2 
Generates the unsigned release APK on each commit to the `main` branch and pushes it to the `apk-unsigned` branch and also uploads the APK as a workflow artifact.

## Summary by Sourcery

Add a GitHub Actions workflow to build an unsigned Android release APK on each commit to main, push it to the apk-unsigned branch, and upload it as a workflow artifact.

Enhancements:
- Automate unsigned APK generation and distribution for Android releases.

CI:
- Introduce an 'unsigned' job in the CI pipeline using a composite action to set up Flutter, build the unsigned APK, commit it to the apk-unsigned branch, and upload it as an artifact.