### PR TITLE
feat: added Image tune-adjust feature

### DIFF
--- a/lib/constants/string_constants.dart
+++ b/lib/constants/string_constants.dart
@@ -1,3 +1,10 @@
 class StringConstants {
   static const String appName = 'Magic epaper';
+  static const String noImageSelectedFeedback = 'Import an image first!';
+  static const String adjustButtonLabel = 'Adjust';
+  static const String importImageButtonLabel = 'Import New';
+  static const String openEditor = 'Open Editor';
+  static const String importStartingImageFeedback = "Import an image to begin";
+  static const String transferButtonLabel = 'Transfer';
+  static const String filterScreenTitle = 'Select a Filter';
 }

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -223,8 +223,7 @@ class BottomActionMenu extends StatelessWidget {
                 context: context,
                 icon: Icons.tune_rounded,
                 label: 'Adjust',
-                onTap: () async 
-                {
+                onTap: () async {
                   if (imgLoader.image != null) {
                     final canvasBytes = await Navigator.of(context)
                         .push<Uint8List>(MaterialPageRoute(
@@ -244,8 +243,7 @@ class BottomActionMenu extends StatelessWidget {
                           emojiEditor: EmojiEditorConfigs(enabled: false),
                         ),
                       ),
-                    )
-                    );
+                    ));
                     if (canvasBytes != null) {
                       imgLoader.updateImage(
                         bytes: canvasBytes,

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -10,6 +10,7 @@ import 'package:image/image.dart' as img;
 import 'package:magic_epaper_app/provider/image_loader.dart';
 import 'package:magic_epaper_app/util/epd/epd.dart';
 import 'package:magic_epaper_app/constants/color_constants.dart';
+import 'package:magic_epaper_app/constants/string_constants.dart';
 import 'package:magic_epaper_app/util/protocol.dart';
 
 class ImageEditor extends StatefulWidget {
@@ -96,7 +97,7 @@ class _ImageEditorState extends State<ImageEditor> {
         backgroundColor: colorAccent,
         elevation: 0,
         title: const Text(
-          'Select a Filter',
+          StringConstants.filterScreenTitle,
           style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
         ),
         actions: <Widget>[
@@ -123,7 +124,7 @@ class _ImageEditorState extends State<ImageEditor> {
                     side: const BorderSide(color: Colors.white, width: 1),
                   ),
                 ),
-                child: const Text('Transfer'),
+                child: const Text(StringConstants.transferButtonLabel),
               ),
             ),
         ],
@@ -145,7 +146,7 @@ class _ImageEditorState extends State<ImageEditor> {
                 )
               : const Center(
                   child: Text(
-                    "Import an image to begin",
+                    StringConstants.importStartingImageFeedback,
                     style: TextStyle(color: Colors.grey, fontSize: 16),
                   ),
                 ),
@@ -177,7 +178,7 @@ class BottomActionMenu extends StatelessWidget {
         color: Colors.white,
         boxShadow: [
           BoxShadow(
-            color: colorBlack.withOpacity(0.1),
+            color: colorBlack.withValues(alpha: .1),
             spreadRadius: 0,
             blurRadius: 10,
             offset: const Offset(0, -5),
@@ -193,7 +194,7 @@ class BottomActionMenu extends StatelessWidget {
               _buildActionButton(
                 context: context,
                 icon: Icons.add_photo_alternate_outlined,
-                label: 'Import New',
+                label: StringConstants.importImageButtonLabel,
                 onTap: () {
                   imgLoader.pickImage(width: epd.width, height: epd.height);
                 },
@@ -201,7 +202,7 @@ class BottomActionMenu extends StatelessWidget {
               _buildActionButton(
                 context: context,
                 icon: Icons.edit_outlined,
-                label: 'Open Editor',
+                label: StringConstants.openEditor,
                 onTap: () async {
                   final canvasBytes =
                       await Navigator.of(context).push<Uint8List>(
@@ -222,7 +223,7 @@ class BottomActionMenu extends StatelessWidget {
               _buildActionButton(
                 context: context,
                 icon: Icons.tune_rounded,
-                label: 'Adjust',
+                label: StringConstants.adjustButtonLabel,
                 onTap: () async {
                   if (imgLoader.image != null) {
                     final canvasBytes = await Navigator.of(context)
@@ -255,7 +256,7 @@ class BottomActionMenu extends StatelessWidget {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                           duration: Durations.medium4,
-                          content: Text('Import an image first!'),
+                          content: Text(StringConstants.noImageSelectedFeedback),
                           backgroundColor: colorPrimary),
                     );
                   }

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/movable_background_image.dart';
 import 'package:magic_epaper_app/util/image_editor_utils.dart';
 import 'package:magic_epaper_app/view/widget/image_list.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:provider/provider.dart';
 import 'package:image/image.dart' as img;
 
@@ -214,6 +215,50 @@ class BottomActionMenu extends StatelessWidget {
                       bytes: canvasBytes,
                       width: epd.width,
                       height: epd.height,
+                    );
+                  }
+                },
+              ),
+              _buildActionButton(
+                context: context,
+                icon: Icons.tune_rounded,
+                label: 'Adjust',
+                onTap: () async 
+                {
+                  if (imgLoader.image != null) {
+                    final canvasBytes = await Navigator.of(context)
+                        .push<Uint8List>(MaterialPageRoute(
+                      builder: (context) => ProImageEditor.memory(
+                        img.encodeJpg(imgLoader.image!),
+                        callbacks: ProImageEditorCallbacks(
+                          onImageEditingComplete: (Uint8List bytes) async {
+                            Navigator.pop(context, bytes);
+                          },
+                        ),
+                        configs: const ProImageEditorConfigs(
+                          paintEditor: PaintEditorConfigs(enabled: false),
+                          textEditor: TextEditorConfigs(enabled: false),
+                          cropRotateEditor: CropRotateEditorConfigs(
+                            enabled: false,
+                          ),
+                          emojiEditor: EmojiEditorConfigs(enabled: false),
+                        ),
+                      ),
+                    )
+                    );
+                    if (canvasBytes != null) {
+                      imgLoader.updateImage(
+                        bytes: canvasBytes,
+                        width: epd.width,
+                        height: epd.height,
+                      );
+                    }
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          duration: Durations.medium4,
+                          content: Text('Import an image first!'),
+                          backgroundColor: colorPrimary),
                     );
                   }
                 },

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -256,7 +256,8 @@ class BottomActionMenu extends StatelessWidget {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                           duration: Durations.medium4,
-                          content: Text(StringConstants.noImageSelectedFeedback),
+                          content:
+                              Text(StringConstants.noImageSelectedFeedback),
                           backgroundColor: colorPrimary),
                     );
                   }


### PR DESCRIPTION
Fixes #51 

This feature provides more fine-tuned control over the output image.

Video Recording:

https://github.com/user-attachments/assets/eae4a55f-055f-421d-a856-c3fe14318f57

## Summary by Sourcery

Add an adjustable image tuning feature to the editor by integrating ProImageEditor, expose it via a new 'Adjust' button in the bottom action menu, and update the displayed image upon completion or prompt for an import if none is loaded.

New Features:
- Integrate ProImageEditor to enable fine-tuned image adjustments.
- Add an 'Adjust' button that launches the ProImageEditor and applies edits to the current image.
- Show a snackbar prompt when users attempt adjustment without an imported image.