### PR TITLE
feat: retain last finalized image after app restart.

### DIFF
--- a/lib/provider/image_loader.dart
+++ b/lib/provider/image_loader.dart
@@ -1,30 +1,68 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
 
 class ImageLoader extends ChangeNotifier {
   img.Image? image;
   final List<img.Image> processedImgs = List.empty(growable: true);
+  bool isLoading = false;
 
-  void pickImage({required int width, required int height}) async {
+  Future<bool> pickImage({required int width, required int height}) async {
     final ImagePicker picker = ImagePicker();
     final XFile? file = await picker.pickImage(source: ImageSource.gallery);
-    if (file == null) return;
+    if (file == null) return false;
 
     final croppedFile = await ImageCropper().cropImage(
       sourcePath: file.path,
-      aspectRatio:
-          CropAspectRatio(ratioX: width.toDouble(), ratioY: height.toDouble()),
+      aspectRatio: CropAspectRatio(
+        ratioX: width.toDouble(),
+        ratioY: height.toDouble(),
+      ),
     );
-    if (croppedFile == null) return;
+    if (croppedFile == null) return false;
 
     processedImgs.clear();
     image = await img.decodeImageFile(croppedFile.path);
 
     notifyListeners();
+    return true;
+  }
+
+  Future<void> saveFinalizedImageBytes(Uint8List bytes) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File(path.join(dir.path, 'last_finalized.png'));
+    await file.writeAsBytes(bytes);
+  }
+
+  Future<void> loadFinalizedImage({
+    required int width,
+    required int height,
+  }) async {
+    isLoading = true;
+    notifyListeners();
+
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/last_finalized.png');
+
+      if (await file.exists()) {
+        final bytes = await file.readAsBytes();
+        final decoded = img.decodeImage(bytes);
+        if (decoded != null) {
+          final resized = img.copyResize(decoded, width: width, height: height);
+          image = resized;
+        }
+      }
+    } finally {
+      isLoading = false;
+      notifyListeners();
+    }
   }
 
   Future<void> updateImage({

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -28,6 +28,20 @@ class _ImageEditorState extends State<ImageEditor> {
   List<img.Image> _rawImages = [];
   List<Uint8List> _processedPngs = [];
 
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      final imgLoader = context.read<ImageLoader>();
+      if (imgLoader.image == null) {
+        imgLoader.loadFinalizedImage(
+          width: widget.epd.width,
+          height: widget.epd.height,
+        );
+      }
+    });
+  }
+
   void _onFilterSelected(int index) {
     if (_selectedFilterIndex != index) {
       setState(() {
@@ -127,29 +141,36 @@ class _ImageEditorState extends State<ImageEditor> {
             ),
         ],
       ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8.0),
-          child: _processedPngs.isNotEmpty
-              ? ImageList(
-                  key: ValueKey(_processedSourceImage),
-                  processedPngs: _processedPngs,
-                  epd: widget.epd,
-                  selectedIndex: _selectedFilterIndex,
-                  flipHorizontal: flipHorizontal,
-                  flipVertical: flipVertical,
-                  onFilterSelected: _onFilterSelected,
-                  onFlipHorizontal: toggleFlipHorizontal,
-                  onFlipVertical: toggleFlipVertical,
-                )
-              : const Center(
-                  child: Text(
-                    "Import an image to begin",
-                    style: TextStyle(color: Colors.grey, fontSize: 16),
-                  ),
-                ),
-        ),
-      ),
+      body: imgLoader.isLoading
+          ? const Center(
+              child: Text('Loading...',
+                  style: TextStyle(
+                    color: colorBlack,
+                    fontSize: 14,
+                  )))
+          : SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: _processedPngs.isNotEmpty
+                    ? ImageList(
+                        key: ValueKey(_processedSourceImage),
+                        processedPngs: _processedPngs,
+                        epd: widget.epd,
+                        selectedIndex: _selectedFilterIndex,
+                        flipHorizontal: flipHorizontal,
+                        flipVertical: flipVertical,
+                        onFilterSelected: _onFilterSelected,
+                        onFlipHorizontal: toggleFlipHorizontal,
+                        onFlipVertical: toggleFlipVertical,
+                      )
+                    : const Center(
+                        child: Text(
+                          "Import an image to begin",
+                          style: TextStyle(color: Colors.grey, fontSize: 16),
+                        ),
+                      ),
+              ),
+            ),
       bottomNavigationBar: BottomActionMenu(
         epd: widget.epd,
         imgLoader: imgLoader,
@@ -193,8 +214,14 @@ class BottomActionMenu extends StatelessWidget {
                 context: context,
                 icon: Icons.add_photo_alternate_outlined,
                 label: 'Import New',
-                onTap: () {
-                  imgLoader.pickImage(width: epd.width, height: epd.height);
+                onTap: () async {
+                  final success = await imgLoader.pickImage(
+                      width: epd.width, height: epd.height);
+                  if (success && imgLoader.image != null) {
+                    final bytes =
+                        Uint8List.fromList(img.encodePng(imgLoader.image!));
+                    await imgLoader.saveFinalizedImageBytes(bytes);
+                  }
                 },
               ),
               _buildActionButton(
@@ -210,11 +237,12 @@ class BottomActionMenu extends StatelessWidget {
                     ),
                   );
                   if (canvasBytes != null) {
-                    imgLoader.updateImage(
+                    await imgLoader.updateImage(
                       bytes: canvasBytes,
                       width: epd.width,
                       height: epd.height,
                     );
+                    await imgLoader.saveFinalizedImageBytes(canvasBytes);
                   }
                 },
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   intl: ^0.19.0
   path_provider: ^2.0.15
   get_it: ^8.0.3
+  path: ^1.9.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes: #50
caching and restoring the last finalized image. Image is restored only once using imgLoader.image == null to avoid reloading on every time Filter screen open, it loads image from cache only the first time when the Filter screen opens, this improves performance and preserves user progress after restarts.

Continued work on [#53](https://github.com/fossasia/magic-epaper-app/pull/53) as it had some merge conflicts.