### PR TITLE
WIP: added color adjust feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:magic_epaper_app/provider/color_adjustment_provider.dart';
 import 'package:magic_epaper_app/provider/getitlocator.dart';
 import 'package:magic_epaper_app/provider/image_loader.dart';
 import 'package:provider/provider.dart';
@@ -8,6 +9,7 @@ void main() {
   setupLocator();
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (context) => ImageLoader()),
+    ChangeNotifierProvider(create: (context) => ColorAdjustmentProvider()),
   ], child: const MyApp()));
 }
 

--- a/lib/provider/color_adjustment_provider.dart
+++ b/lib/provider/color_adjustment_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class ColorAdjustmentProvider extends ChangeNotifier {
+  Map<Color, double> _weights = {};
+
+  Map<Color, double> get weights => _weights;
+
+  void resetWeights(List<Color> colors) {
+    _weights = {for (var color in colors) color: 1.0};
+  }
+
+  void updateWeights(Map<Color, double> newWeights) {
+    _weights = newWeights;
+    notifyListeners();
+  }
+}

--- a/lib/util/epd/epd.dart
+++ b/lib/util/epd/epd.dart
@@ -7,7 +7,8 @@ import 'package:magic_epaper_app/util/image_processing/image_processing.dart';
 abstract class Epd {
   int get width;
   int get height;
-  final processingMethods = <img.Image Function(img.Image)>[];
+  final processingMethods =
+      <img.Image Function(img.Image, Map<Color, double>)>[];
   String get name;
   String get modelId;
   String get imgPath;

--- a/lib/util/image_editor_utils.dart
+++ b/lib/util/image_editor_utils.dart
@@ -1,9 +1,11 @@
+import 'dart:ui';
 import 'package:image/image.dart' as img;
 import 'package:magic_epaper_app/util/epd/epd.dart';
 
 List<img.Image> processImages({
   required img.Image originalImage,
   required Epd epd,
+  required Map<Color, double> weights,
 }) {
   final List<img.Image> processedImgs = [];
 
@@ -14,7 +16,7 @@ List<img.Image> processImages({
   );
 
   for (final method in epd.processingMethods) {
-    processedImgs.add(method(transformed));
+    processedImgs.add(method(transformed, weights));
   }
 
   return processedImgs;

--- a/lib/util/image_processing/image_processing.dart
+++ b/lib/util/image_processing/image_processing.dart
@@ -5,81 +5,95 @@ import 'extract_quantizer.dart';
 import 'remap_quantizer.dart';
 
 class ImageProcessing {
-  static img.Image bwFloydSteinbergDither(img.Image orgImg) {
+  static img.Image bwFloydSteinbergDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
     return img.ditherImage(image, quantizer: img.BinaryQuantizer());
   }
 
-  static img.Image bwFalseFloydSteinbergDither(img.Image orgImg) {
+  static img.Image bwFalseFloydSteinbergDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
     return img.ditherImage(image,
         quantizer: img.BinaryQuantizer(),
         kernel: img.DitherKernel.falseFloydSteinberg);
   }
 
-  static img.Image bwStuckiDither(img.Image orgImg) {
+  static img.Image bwStuckiDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
     return img.ditherImage(image,
         quantizer: img.BinaryQuantizer(), kernel: img.DitherKernel.stucki);
   }
 
-  static img.Image bwAtkinsonDither(img.Image orgImg) {
+  static img.Image bwAtkinsonDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
     return img.ditherImage(image,
         quantizer: img.BinaryQuantizer(), kernel: img.DitherKernel.atkinson);
   }
 
-  static img.Image bwThreshold(img.Image orgImg) {
+  static img.Image bwThreshold(img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
     return img.ditherImage(image,
         quantizer: img.BinaryQuantizer(), kernel: img.DitherKernel.none);
   }
 
-  static img.Image bwHalftoneDither(img.Image orgImg) {
+  static img.Image bwHalftoneDither(
+      img.Image orgImg, Map<Color, double> weights) {
     final image = img.Image.from(orgImg);
     img.grayscale(image);
     img.colorHalftone(image, size: 3);
     return img.ditherImage(image, quantizer: img.BinaryQuantizer());
   }
 
-  static img.Image bwrHalftone(img.Image orgImg) {
+  static img.Image bwrHalftone(img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
 
     img.colorHalftone(image, size: 3);
     return img.ditherImage(image,
-        quantizer: RemapQuantizer(palette: _createTriColorPalette()),
+        quantizer:
+            RemapQuantizer(palette: _createTriColorPalette(), weights: weights),
         kernel: img.DitherKernel.floydSteinberg);
   }
 
-  static img.Image bwrFloydSteinbergDither(img.Image orgImg) {
+  static img.Image bwrFloydSteinbergDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
 
     return img.ditherImage(image,
-        quantizer: RemapQuantizer(palette: _createTriColorPalette()),
+        quantizer:
+            RemapQuantizer(palette: _createTriColorPalette(), weights: weights),
         kernel: img.DitherKernel.floydSteinberg);
   }
 
-  static img.Image bwrFalseFloydSteinbergDither(img.Image orgImg) {
+  static img.Image bwrFalseFloydSteinbergDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
 
     return img.ditherImage(image,
-        quantizer: RemapQuantizer(palette: _createTriColorPalette()),
+        quantizer:
+            RemapQuantizer(palette: _createTriColorPalette(), weights: weights),
         kernel: img.DitherKernel.falseFloydSteinberg);
   }
 
-  static img.Image bwrStuckiDither(img.Image orgImg) {
+  static img.Image bwrStuckiDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
 
     return img.ditherImage(image,
-        quantizer: RemapQuantizer(palette: _createTriColorPalette()),
+        quantizer:
+            RemapQuantizer(palette: _createTriColorPalette(), weights: weights),
         kernel: img.DitherKernel.stucki);
   }
 
-  static img.Image bwrTriColorAtkinsonDither(img.Image orgImg) {
+  static img.Image bwrTriColorAtkinsonDither(
+      img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
 
     return img.ditherImage(image,
-        quantizer: RemapQuantizer(palette: _createTriColorPalette()),
+        quantizer:
+            RemapQuantizer(palette: _createTriColorPalette(), weights: weights),
         kernel: img.DitherKernel.atkinson);
   }
 
@@ -91,11 +105,12 @@ class ImageProcessing {
         kernel: img.DitherKernel.none);
   }
 
-  static img.Image bwrThreshold(img.Image orgImg) {
+  static img.Image bwrThreshold(img.Image orgImg, Map<Color, double> weights) {
     var image = img.Image.from(orgImg);
 
     return img.ditherImage(image,
-        quantizer: RemapQuantizer(palette: _createTriColorPalette()),
+        quantizer:
+            RemapQuantizer(palette: _createTriColorPalette(), weights: weights),
         kernel: img.DitherKernel.none);
   }
 }

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -223,8 +223,7 @@ class BottomActionMenu extends StatelessWidget {
                 context: context,
                 icon: Icons.tune_rounded,
                 label: 'Adjust',
-                onTap: () async 
-                {
+                onTap: () async {
                   if (imgLoader.image != null) {
                     final canvasBytes = await Navigator.of(context)
                         .push<Uint8List>(MaterialPageRoute(
@@ -244,8 +243,7 @@ class BottomActionMenu extends StatelessWidget {
                           emojiEditor: EmojiEditorConfigs(enabled: false),
                         ),
                       ),
-                    )
-                    );
+                    ));
                     if (canvasBytes != null) {
                       imgLoader.updateImage(
                         bytes: canvasBytes,

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/movable_background_image.dart';
 import 'package:magic_epaper_app/util/image_editor_utils.dart';
 import 'package:magic_epaper_app/view/widget/image_list.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:provider/provider.dart';
 import 'package:image/image.dart' as img;
 
@@ -214,6 +215,50 @@ class BottomActionMenu extends StatelessWidget {
                       bytes: canvasBytes,
                       width: epd.width,
                       height: epd.height,
+                    );
+                  }
+                },
+              ),
+              _buildActionButton(
+                context: context,
+                icon: Icons.tune_rounded,
+                label: 'Adjust',
+                onTap: () async 
+                {
+                  if (imgLoader.image != null) {
+                    final canvasBytes = await Navigator.of(context)
+                        .push<Uint8List>(MaterialPageRoute(
+                      builder: (context) => ProImageEditor.memory(
+                        img.encodeJpg(imgLoader.image!),
+                        callbacks: ProImageEditorCallbacks(
+                          onImageEditingComplete: (Uint8List bytes) async {
+                            Navigator.pop(context, bytes);
+                          },
+                        ),
+                        configs: const ProImageEditorConfigs(
+                          paintEditor: PaintEditorConfigs(enabled: false),
+                          textEditor: TextEditorConfigs(enabled: false),
+                          cropRotateEditor: CropRotateEditorConfigs(
+                            enabled: false,
+                          ),
+                          emojiEditor: EmojiEditorConfigs(enabled: false),
+                        ),
+                      ),
+                    )
+                    );
+                    if (canvasBytes != null) {
+                      imgLoader.updateImage(
+                        bytes: canvasBytes,
+                        width: epd.width,
+                        height: epd.height,
+                      );
+                    }
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          duration: Durations.medium4,
+                          content: Text('Import an image first!'),
+                          backgroundColor: colorPrimary),
                     );
                   }
                 },

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -1,6 +1,9 @@
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/movable_background_image.dart';
+import 'package:magic_epaper_app/provider/color_adjustment_provider.dart';
+import 'package:magic_epaper_app/provider/color_palette_provider.dart';
+import 'package:magic_epaper_app/provider/getitlocator.dart';
 import 'package:magic_epaper_app/util/image_editor_utils.dart';
 import 'package:magic_epaper_app/view/widget/image_list.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -11,6 +14,8 @@ import 'package:magic_epaper_app/provider/image_loader.dart';
 import 'package:magic_epaper_app/util/epd/epd.dart';
 import 'package:magic_epaper_app/constants/color_constants.dart';
 import 'package:magic_epaper_app/util/protocol.dart';
+
+final _colors = getIt<ColorPaletteProvider>().colors;
 
 class ImageEditor extends StatefulWidget {
   final Epd epd;
@@ -28,6 +33,15 @@ class _ImageEditorState extends State<ImageEditor> {
   img.Image? _processedSourceImage;
   List<img.Image> _rawImages = [];
   List<Uint8List> _processedPngs = [];
+  Map<Color, double> _currentWeights = {};
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ColorAdjustmentProvider>().resetWeights(_colors);
+    });
+  }
 
   void _onFilterSelected(int index) {
     if (_selectedFilterIndex != index) {
@@ -49,7 +63,8 @@ class _ImageEditorState extends State<ImageEditor> {
     });
   }
 
-  void _updateProcessedImages(img.Image? sourceImage) {
+  void _updateProcessedImages(
+      img.Image? sourceImage, Map<Color, double> weights) {
     if (sourceImage == null) {
       if (_rawImages.isNotEmpty) {
         setState(() {
@@ -61,13 +76,15 @@ class _ImageEditorState extends State<ImageEditor> {
       return;
     }
 
-    if (_processedSourceImage == sourceImage) {
+    if (_processedSourceImage == sourceImage &&
+        _currentWeights.toString() == weights.toString()) {
       return;
     }
 
     _rawImages = processImages(
       originalImage: sourceImage,
       epd: widget.epd,
+      weights: weights,
     );
 
     _processedPngs = _rawImages
@@ -76,16 +93,25 @@ class _ImageEditorState extends State<ImageEditor> {
 
     setState(() {
       _processedSourceImage = sourceImage;
-      _selectedFilterIndex = 0;
-      flipHorizontal = false;
-      flipVertical = false;
+      _currentWeights = weights;
+      if (_processedSourceImage != sourceImage) {
+        _selectedFilterIndex = 0;
+        flipHorizontal = false;
+        flipVertical = false;
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
     var imgLoader = context.watch<ImageLoader>();
-    _updateProcessedImages(imgLoader.image);
+    var colorAdjuster = context.watch<ColorAdjustmentProvider>();
+
+    if (imgLoader.image != null && colorAdjuster.weights.isEmpty) {
+      colorAdjuster.resetWeights(_colors);
+    }
+
+    _updateProcessedImages(imgLoader.image, colorAdjuster.weights);
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -154,6 +180,7 @@ class _ImageEditorState extends State<ImageEditor> {
       bottomNavigationBar: BottomActionMenu(
         epd: widget.epd,
         imgLoader: imgLoader,
+        colors: _colors,
       ),
     );
   }
@@ -162,15 +189,26 @@ class _ImageEditorState extends State<ImageEditor> {
 class BottomActionMenu extends StatelessWidget {
   final Epd epd;
   final ImageLoader imgLoader;
+  final List<Color> colors;
 
   const BottomActionMenu({
     super.key,
     required this.epd,
     required this.imgLoader,
+    required this.colors,
   });
+
+  void _showColorAdjustmentSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.white,
+      builder: (_) => ColorAdjustmentSliders(colors: colors),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    var colorAdjuster = context.watch<ColorAdjustmentProvider>();
     return Container(
       height: 75,
       decoration: BoxDecoration(
@@ -196,6 +234,7 @@ class BottomActionMenu extends StatelessWidget {
                 label: 'Import New',
                 onTap: () {
                   imgLoader.pickImage(width: epd.width, height: epd.height);
+                  colorAdjuster.resetWeights(_colors);
                 },
               ),
               _buildActionButton(
@@ -211,6 +250,7 @@ class BottomActionMenu extends StatelessWidget {
                     ),
                   );
                   if (canvasBytes != null) {
+                    colorAdjuster.resetWeights(_colors);
                     imgLoader.updateImage(
                       bytes: canvasBytes,
                       width: epd.width,
@@ -250,7 +290,25 @@ class BottomActionMenu extends StatelessWidget {
                         width: epd.width,
                         height: epd.height,
                       );
+                      colorAdjuster.resetWeights(_colors);
                     }
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          duration: Durations.medium4,
+                          content: Text('Import an image first!'),
+                          backgroundColor: colorPrimary),
+                    );
+                  }
+                },
+              ),
+              _buildActionButton(
+                context: context,
+                icon: Icons.palette_outlined,
+                label: 'Adjust Colors',
+                onTap: () {
+                  if (imgLoader.image != null) {
+                    _showColorAdjustmentSheet(context);
                   } else {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
@@ -291,6 +349,113 @@ class BottomActionMenu extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class ColorAdjustmentSliders extends StatefulWidget {
+  final List<Color> colors;
+  const ColorAdjustmentSliders({super.key, required this.colors});
+
+  @override
+  State<ColorAdjustmentSliders> createState() => _ColorAdjustmentSlidersState();
+}
+
+class _ColorAdjustmentSlidersState extends State<ColorAdjustmentSliders> {
+  late Map<Color, double> _localWeights;
+
+  @override
+  void initState() {
+    super.initState();
+    _localWeights = Map<Color, double>.from(
+        context.read<ColorAdjustmentProvider>().weights);
+  }
+
+  String _getColorName(Color color) {
+    if (color == Colors.black) return 'Black';
+    if (color == Colors.white) return 'White';
+    if (color == Colors.red) return 'Red';
+    return 'Color';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorAdjuster = context.read<ColorAdjustmentProvider>();
+
+    return Padding(
+      padding: const EdgeInsets.all(20.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Adjust Color Intensity',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          ...widget.colors.map((color) {
+            return Row(
+              children: [
+                Container(
+                  width: 24,
+                  height: 24,
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: Colors.grey.shade400),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Text(_getColorName(color),
+                    style: const TextStyle(fontSize: 16)),
+                Expanded(
+                  child: Slider(
+                    value: _localWeights[color] ?? 1.0,
+                    min: 0.0,
+                    max: 10.0,
+                    divisions: 30,
+                    label: (_localWeights[color] ?? 1.0).toStringAsFixed(1),
+                    activeColor: colorAccent,
+                    onChanged: (newValue) {
+                      setState(() {
+                        _localWeights[color] = newValue;
+                      });
+                    },
+                  ),
+                ),
+              ],
+            );
+          }),
+          const SizedBox(height: 10),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () {
+                  setState(() {
+                    for (var key in _localWeights.keys) {
+                      _localWeights[key] = 1.0;
+                    }
+                  });
+                },
+                child: const Text('Reset'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colorAccent,
+                  foregroundColor: Colors.white,
+                ),
+                onPressed: () {
+                  colorAdjuster.updateWeights(_localWeights);
+                  Navigator.pop(context);
+                },
+                child: const Text('Apply'),
+              ),
+            ],
+          )
+        ],
       ),
     );
   }


### PR DESCRIPTION
Fixes #60 

Screen Recording:

https://github.com/user-attachments/assets/a003a5df-bbb0-4fa0-a324-a96f8a83f949


Issues:

- Doesn't work for Black/white images as it is using black/white quantizer. This can be fixed by converting them to use the remap quantizer 

I would like someone to review this first , and suggest if it is a viable solution , and then I can update this PR

## Summary by Sourcery

Implement a color adjustment feature by introducing a provider-driven weight model, a slider-based UI for per-color intensity control, and integrating those weights into the image processing pipeline’s quantizer while also offering manual editing via ProImageEditor.

New Features:
- Add ColorAdjustmentProvider to manage per-color intensity weights
- Introduce 'Adjust Colors' bottom sheet with sliders to control individual color contributions
- Add an 'Adjust' button integrating ProImageEditor for manual image edits prior to color adjustment

Enhancements:
- Refactor image processing pipeline and Epd interface to pass color weights through RemapQuantizer
- Modify RemapQuantizer to factor in adjustable weights when mapping pixels to palette colors
- Reset color weights on new imports and after manual edits to ensure consistent baseline