### PR TITLE
feat: Implemented UI for quick lut

### DIFF
--- a/lib/util/epd/driver/driver.dart
+++ b/lib/util/epd/driver/driver.dart
@@ -14,5 +14,6 @@ abstract class Driver {
   int get pllControl;
   WaveformList get waveforms;
   Future<void> setlut(Protocol p, Waveform waveform);
-  Future<void> init(Protocol p);
+
+  Future<void> init(Protocol p, {bool useQuickLut = false});
 }

--- a/lib/util/epd/driver/driver.dart
+++ b/lib/util/epd/driver/driver.dart
@@ -15,5 +15,5 @@ abstract class Driver {
   WaveformList get waveforms;
   Future<void> setlut(Protocol p, Waveform waveform);
 
-  Future<void> init(Protocol p, {bool useQuickLut = false});
+  Future<void> init(Protocol p, {Waveform? waveform});
 }

--- a/lib/util/epd/driver/uc8253.dart
+++ b/lib/util/epd/driver/uc8253.dart
@@ -123,7 +123,7 @@ class Uc8253 extends Driver {
   }
 
   @override
-  Future<void> init(Protocol p) async {
+  Future<void> init(Protocol p, {bool useQuickLut = false}) async {
     // power on
     // FIXME: this command require polling the busy state but currently there is no way to do this in the app
     await p.writeMsg(Uint8List.fromList([p.fw.epdCmd, 0x04]));
@@ -133,10 +133,12 @@ class Uc8253 extends Driver {
     await p.writeMsg(Uint8List.fromList([p.fw.epdSend, 0xff, 0x0f]));
 
     await p.writeMsg(Uint8List.fromList([p.fw.epdCmd, panelSetting]));
-    // 480x240, built-in LUTs
-    await p.writeMsg(Uint8List.fromList([p.fw.epdSend, 0xCF, 0x8D]));
-    // 480x240, LUTs from register
-    // await p.writeMsg(Uint8List.fromList([p.fw.epdSend, 0xEF, 0x8D]));
-    // await setlut(p, waveforms[0]);
+
+    if (useQuickLut) {
+      await p.writeMsg(Uint8List.fromList([p.fw.epdSend, 0xEF, 0x8D]));
+      await setlut(p, waveforms[0]);
+    } else {
+      await p.writeMsg(Uint8List.fromList([p.fw.epdSend, 0xCF, 0x8D]));
+    }
   }
 }

--- a/lib/util/epd/driver/uc8253.dart
+++ b/lib/util/epd/driver/uc8253.dart
@@ -125,7 +125,7 @@ class Uc8253 extends Driver {
   }
 
   @override
-   Future<void> init(Protocol p, {Waveform? waveform}) async {
+  Future<void> init(Protocol p, {Waveform? waveform}) async {
     // power on
     // FIXME: this command require polling the busy state but currently there is no way to do this in the app
     await p.writeMsg(Uint8List.fromList([p.fw.epdCmd, 0x04]));

--- a/lib/util/epd/driver/uc8253.dart
+++ b/lib/util/epd/driver/uc8253.dart
@@ -11,6 +11,8 @@ class QuickLut extends Waveform {
   @override
   String get desc => "Quick waveform for R_sense = 4R7 and PLL = 10Hz";
   @override
+  String get name => "Quick Refresh";
+  @override
   int get pll => 0x01; // 10Hz
   @override
   List<Lut> get luts => [
@@ -123,7 +125,7 @@ class Uc8253 extends Driver {
   }
 
   @override
-  Future<void> init(Protocol p, {bool useQuickLut = false}) async {
+   Future<void> init(Protocol p, {Waveform? waveform}) async {
     // power on
     // FIXME: this command require polling the busy state but currently there is no way to do this in the app
     await p.writeMsg(Uint8List.fromList([p.fw.epdCmd, 0x04]));
@@ -134,10 +136,11 @@ class Uc8253 extends Driver {
 
     await p.writeMsg(Uint8List.fromList([p.fw.epdCmd, panelSetting]));
 
-    if (useQuickLut) {
+    if (waveform != null) {
       await p.writeMsg(Uint8List.fromList([p.fw.epdSend, 0xEF, 0x8D]));
-      await setlut(p, waveforms[0]);
+      await setlut(p, waveform);
     } else {
+      // Otherwise, use the settings for a full refresh.
       await p.writeMsg(Uint8List.fromList([p.fw.epdSend, 0xCF, 0x8D]));
     }
   }

--- a/lib/util/epd/driver/waveform.dart
+++ b/lib/util/epd/driver/waveform.dart
@@ -11,6 +11,7 @@ class Lut {
 // A set of luts for a display
 abstract class Waveform {
   String get desc;
+  String get name;
   int get pll;
   List<Lut> get luts;
 }

--- a/lib/util/protocol.dart
+++ b/lib/util/protocol.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:image/image.dart' as img;
+import 'package:magic_epaper_app/util/epd/driver/waveform.dart';
 import 'package:magic_epaper_app/util/epd/epd.dart';
 import 'package:app_settings/app_settings.dart';
 import 'package:magic_epaper_app/util/magic_epaper_firmware.dart';
@@ -95,7 +96,7 @@ class Protocol {
     return chunks;
   }
 
-  void writeImages(img.Image image, {bool useQuickLut = false}) async {
+ void writeImages(img.Image image, {Waveform? waveform}) async {
     var availability = await FlutterNfcKit.nfcAvailability;
     switch (availability) {
       case NFCAvailability.available:
@@ -128,7 +129,7 @@ class Protocol {
     await Future.delayed(
         const Duration(seconds: 2)); // waiting for the power supply stable
 
-    await epd.controller.init(this, useQuickLut: useQuickLut);
+    await epd.controller.init(this, waveform: waveform);
 
     final epdColors = epd.extractEpaperColorFrames(image);
     final transmissionLines = epd.controller.transmissionLines.iterator;

--- a/lib/util/protocol.dart
+++ b/lib/util/protocol.dart
@@ -96,7 +96,7 @@ class Protocol {
     return chunks;
   }
 
- void writeImages(img.Image image, {Waveform? waveform}) async {
+  void writeImages(img.Image image, {Waveform? waveform}) async {
     var availability = await FlutterNfcKit.nfcAvailability;
     switch (availability) {
       case NFCAvailability.available:

--- a/lib/util/protocol.dart
+++ b/lib/util/protocol.dart
@@ -95,7 +95,7 @@ class Protocol {
     return chunks;
   }
 
-  void writeImages(img.Image image) async {
+  void writeImages(img.Image image, {bool useQuickLut = false}) async {
     var availability = await FlutterNfcKit.nfcAvailability;
     switch (availability) {
       case NFCAvailability.available:
@@ -128,7 +128,7 @@ class Protocol {
     await Future.delayed(
         const Duration(seconds: 2)); // waiting for the power supply stable
 
-    await epd.controller.init(this);
+    await epd.controller.init(this, useQuickLut: useQuickLut);
 
     final epdColors = epd.extractEpaperColorFrames(image);
     final transmissionLines = epd.controller.transmissionLines.iterator;

--- a/lib/util/protocol.dart
+++ b/lib/util/protocol.dart
@@ -104,14 +104,12 @@ class Protocol {
     return chunks;
   }
 
-
-Future<void> writeImages(
+  Future<void> writeImages(
     img.Image image, {
     ProgressCallback? onProgress,
     TagDetectedCallback? onTagDetected,
-    {Waveform? waveform}
+    Waveform? waveform,
   }) async {
-
     var availability = await FlutterNfcKit.nfcAvailability;
     switch (availability) {
       case NFCAvailability.available:

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -25,6 +25,7 @@ class _ImageEditorState extends State<ImageEditor> {
   int _selectedFilterIndex = 0;
   bool flipHorizontal = false;
   bool flipVertical = false;
+  bool isQuickLutEnabled = false;
 
   img.Image? _processedSourceImage;
   List<img.Image> _rawImages = [];
@@ -116,30 +117,57 @@ class _ImageEditorState extends State<ImageEditor> {
         ),
         actions: <Widget>[
           if (_rawImages.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(right: 12.0),
-              child: TextButton(
-                onPressed: () {
-                  img.Image finalImg = _rawImages[_selectedFilterIndex];
-
-                  if (flipHorizontal) {
-                    finalImg = img.flipHorizontal(finalImg);
-                  }
-                  if (flipVertical) {
-                    finalImg = img.flipVertical(finalImg);
-                  }
-                  Protocol(epd: widget.epd).writeImages(finalImg);
-                },
-                style: TextButton.styleFrom(
-                  backgroundColor: colorAccent,
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                    side: const BorderSide(color: Colors.white, width: 1),
+            Row(
+              children: [
+                IconButton(
+                  tooltip: isQuickLutEnabled ? 'Quick Mode' : 'Normal Mode',
+                  onPressed: () {
+                    setState(() {
+                      isQuickLutEnabled = !isQuickLutEnabled;
+                    });
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        duration: Durations.medium3,
+                        content: Text(
+                          isQuickLutEnabled
+                              ? "Quick Refresh Enabled"
+                              : "Normal Refresh Enabled",
+                        ),
+                        backgroundColor: colorPrimary,
+                      ),
+                    );
+                  },
+                  icon: Icon(
+                    isQuickLutEnabled ? Icons.flash_on : Icons.flash_off,
+                    color: Colors.white,
                   ),
                 ),
-                child: const Text(StringConstants.transferButtonLabel),
-              ),
+                Padding(
+                  padding: const EdgeInsets.only(right: 12.0),
+                  child: TextButton(
+                    onPressed: () {
+                      img.Image finalImg = _rawImages[_selectedFilterIndex];
+
+                      if (flipHorizontal) {
+                        finalImg = img.flipHorizontal(finalImg);
+                      }
+                      if (flipVertical) {
+                        finalImg = img.flipVertical(finalImg);
+                      }
+                      Protocol(epd: widget.epd).writeImages(finalImg);
+                    },
+                    style: TextButton.styleFrom(
+                      backgroundColor: colorAccent,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        side: const BorderSide(color: Colors.white, width: 1),
+                      ),
+                    ),
+                    child: const Text(StringConstants.transferButtonLabel),
+                  ),
+                ),
+              ],
             ),
         ],
       ),

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:magic_epaper_app/image_library/provider/image_library_provider.dart';
 import 'package:magic_epaper_app/image_library/services/image_save_handler.dart';
 import 'package:magic_epaper_app/pro_image_editor/features/movable_background_image.dart';
+import 'package:magic_epaper_app/util/epd/driver/waveform.dart';
 import 'package:magic_epaper_app/util/image_editor_utils.dart';
 import 'package:magic_epaper_app/view/widget/image_list.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -27,7 +28,8 @@ class _ImageEditorState extends State<ImageEditor> {
   int _selectedFilterIndex = 0;
   bool flipHorizontal = false;
   bool flipVertical = false;
-  bool isQuickLutEnabled = false;
+  Waveform? _selectedWaveform;
+  String? _selectedWaveformName;
 
   String _currentImageSource = 'imported';
   img.Image? _processedSourceImage;
@@ -39,6 +41,8 @@ class _ImageEditorState extends State<ImageEditor> {
   @override
   void initState() {
     super.initState();
+    _selectedWaveform = null;
+    _selectedWaveformName = null;
     Future.microtask(() {
       final imgLoader = context.read<ImageLoader>();
       if (imgLoader.image == null) {
@@ -57,11 +61,6 @@ class _ImageEditorState extends State<ImageEditor> {
       context: context,
       provider: context.read<ImageLibraryProvider>(),
     );
-  }
-
-  // Navigate to Image Library using ImageSaveHandler
-  Future<void> _navigateToImageLibrary() async {
-    await _imageSaveHandler!.navigateToImageLibrary();
   }
 
   // Save image using ImageSaveHandler
@@ -139,67 +138,100 @@ class _ImageEditorState extends State<ImageEditor> {
     var imgLoader = context.watch<ImageLoader>();
     _updateProcessedImages(imgLoader.image);
 
+    final List<DropdownMenuItem<String?>> dropdownItems = [
+      const DropdownMenuItem<String?>(
+        value: null,
+        child: Text("Full Refresh"),
+      ),
+      ...widget.epd.controller.waveforms.map((waveform) {
+        return DropdownMenuItem<String?>(
+          value: waveform.name, 
+          child: Text(
+            waveform.name,
+            overflow: TextOverflow.ellipsis,
+          ),
+        );
+      }),
+    ];
+
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
         iconTheme: const IconThemeData(
           color: Colors.white,
         ),
+        titleSpacing: 0.0,
         backgroundColor: colorAccent,
         elevation: 0,
         title: const Text(
           StringConstants.filterScreenTitle,
-          style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          style: TextStyle(
+              color: Colors.white, fontWeight: FontWeight.bold, fontSize: 13.8),
         ),
-        actions: <Widget>[
-          if (_rawImages.isNotEmpty)
-            IconButton(
-              tooltip: isQuickLutEnabled ? 'Quick Mode' : 'Normal Mode',
-              onPressed: () {
-                setState(() {
-                  isQuickLutEnabled = !isQuickLutEnabled;
-                });
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    duration: Durations.medium3,
-                    content: Text(
-                      isQuickLutEnabled
-                          ? "Quick Refresh Enabled"
-                          : "Normal Refresh Enabled",
-                    ),
-                    backgroundColor: colorPrimary,
-                  ),
-                );
-              },
-              icon: Icon(
-                isQuickLutEnabled ? Icons.flash_on : Icons.flash_off,
-                color: Colors.white,
-              ),
-            ),
-          IconButton(
-            onPressed: _navigateToImageLibrary,
-            icon: const Icon(Icons.photo_library_outlined),
-            tooltip: 'Image Library',
-          ),
+        actions: [
           if (_rawImages.isNotEmpty) ...[
-            IconButton(
-              onPressed: _saveCurrentImage,
-              icon: const Icon(Icons.save_outlined),
-              tooltip: 'Save to Library',
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.white, width: 1.2),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String?>(
+                    value: _selectedWaveformName,
+                    hint: const Text(
+                      "Full Refresh",
+                      style: TextStyle(color: Colors.white, fontSize: 16),
+                    ),
+                    isDense: true,
+                    dropdownColor: colorAccent,
+                    style: const TextStyle(color: Colors.white, fontSize: 14),
+                    borderRadius: BorderRadius.circular(8),
+                    icon: const SizedBox.shrink(),
+                    items: dropdownItems,
+                    onChanged: (String? newName) {
+                      setState(() {
+                        _selectedWaveformName = newName;
+                        if (newName == null) {
+                          _selectedWaveform = null; // Full Refresh
+                        } else {
+                          _selectedWaveform = widget.epd.controller.waveforms
+                              .firstWhere((w) => w.name == newName);
+                        }
+                      });
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          duration: Durations.medium3,
+                          content: Text(
+                            _selectedWaveform == null
+                                ? "Full Refresh Selected"
+                                : "${_selectedWaveform!.name} Selected",
+                          ),
+                          backgroundColor: colorPrimary,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
             ),
             Padding(
               padding: const EdgeInsets.only(right: 12.0),
               child: TextButton(
                 onPressed: () {
                   img.Image finalImg = _rawImages[_selectedFilterIndex];
-
                   if (flipHorizontal) {
                     finalImg = img.flipHorizontal(finalImg);
                   }
                   if (flipVertical) {
                     finalImg = img.flipVertical(finalImg);
                   }
-                  Protocol(epd: widget.epd).writeImages(finalImg);
+                  Protocol(epd: widget.epd).writeImages(
+                    finalImg,
+                    waveform: _selectedWaveform,
+                  );
                 },
                 style: TextButton.styleFrom(
                   backgroundColor: colorAccent,
@@ -238,6 +270,7 @@ class _ImageEditorState extends State<ImageEditor> {
                         onFilterSelected: _onFilterSelected,
                         onFlipHorizontal: toggleFlipHorizontal,
                         onFlipVertical: toggleFlipVertical,
+                        onSave: _saveCurrentImage,
                       )
                     : const Center(
                         child: Text(

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -154,7 +154,8 @@ class _ImageEditorState extends State<ImageEditor> {
                       if (flipVertical) {
                         finalImg = img.flipVertical(finalImg);
                       }
-                      Protocol(epd: widget.epd).writeImages(finalImg);
+                      Protocol(epd: widget.epd).writeImages(finalImg,
+                          useQuickLut: isQuickLutEnabled);
                     },
                     style: TextButton.styleFrom(
                       backgroundColor: colorAccent,

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -145,7 +145,7 @@ class _ImageEditorState extends State<ImageEditor> {
       ),
       ...widget.epd.controller.waveforms.map((waveform) {
         return DropdownMenuItem<String?>(
-          value: waveform.name, 
+          value: waveform.name,
           child: Text(
             waveform.name,
             overflow: TextOverflow.ellipsis,

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -192,27 +192,25 @@ class _ImageEditorState extends State<ImageEditor> {
               child: TextButton(
                 onPressed: () {
                   img.Image finalImg = _rawImages[_selectedFilterIndex];
-                      if (flipHorizontal) {
-                        finalImg = img.flipHorizontal(finalImg);
-                      }
-                      if (flipVertical) {
-                        finalImg = img.flipVertical(finalImg);
-                      }
-                      Protocol(epd: widget.epd).writeImages(finalImg,
-                          useQuickLut: isQuickLutEnabled);
-                    },
-                    style: TextButton.styleFrom(
-                      backgroundColor: colorAccent,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        side: const BorderSide(color: Colors.white, width: 1),
-                      ),
-                    ),
-                    child: const Text(StringConstants.transferButtonLabel),
+
+                  if (flipHorizontal) {
+                    finalImg = img.flipHorizontal(finalImg);
+                  }
+                  if (flipVertical) {
+                    finalImg = img.flipVertical(finalImg);
+                  }
+                  Protocol(epd: widget.epd).writeImages(finalImg);
+                },
+                style: TextButton.styleFrom(
+                  backgroundColor: colorAccent,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: const BorderSide(color: Colors.white, width: 1),
                   ),
                 ),
-              ],
+                child: const Text(StringConstants.transferButtonLabel),
+              ),
             ),
           ],
         ],

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -134,7 +134,8 @@ class _ImageEditorState extends State<ImageEditor> {
     });
   }
 
-  Future<void> _showTransferProgress(img.Image finalImg) async {
+  Future<void> _showTransferProgress(img.Image finalImg,
+      {Waveform? waveform}) async {
     await TransferProgressDialog.show(
       context: context,
       finalImg: finalImg,
@@ -143,6 +144,7 @@ class _ImageEditorState extends State<ImageEditor> {
           image,
           onProgress: onProgress,
           onTagDetected: onTagDetected,
+          waveform: waveform,
         );
       },
       colorAccent: colorAccent,
@@ -244,11 +246,8 @@ class _ImageEditorState extends State<ImageEditor> {
                   if (flipVertical) {
                     finalImg = img.flipVertical(finalImg);
                   }
-                  Protocol(epd: widget.epd).writeImages(
-                    finalImg,
-                    waveform: _selectedWaveform,
-                  );
-                  await _showTransferProgress(finalImg);
+                  await _showTransferProgress(finalImg,
+                      waveform: _selectedWaveform);
                 },
                 style: TextButton.styleFrom(
                   backgroundColor: colorAccent,

--- a/lib/view/widget/image_list.dart
+++ b/lib/view/widget/image_list.dart
@@ -14,6 +14,7 @@ class ImageList extends StatelessWidget {
   final Function(int) onFilterSelected;
   final Function() onFlipHorizontal;
   final Function() onFlipVertical;
+  final Function()? onSave;
   final int width;
   final int height;
 
@@ -29,6 +30,7 @@ class ImageList extends StatelessWidget {
     required this.onFlipVertical,
     required this.width,
     required this.height,
+    this.onSave,
   });
 
   String getFilterNameByIndex(int index) {
@@ -80,6 +82,14 @@ class ImageList extends StatelessWidget {
               tooltip: 'Flip Vertically',
               rotation: -1.5708,
             ),
+            if (onSave != null) ...[
+              const SizedBox(width: 16),
+              _buildFlipButton(
+                icon: Icons.save_outlined,
+                onPressed: onSave!,
+                tooltip: 'Save to Library',
+              ),
+            ],
           ],
         ),
         const SizedBox(height: 4),
@@ -107,11 +117,14 @@ class ImageList extends StatelessWidget {
   }
 
   Widget _buildFlipButton({
-    required String assetPath,
+    String? assetPath,
+    IconData? icon,
     required VoidCallback onPressed,
     required String tooltip,
     double rotation = 0.0,
   }) {
+    assert(assetPath != null || icon != null,
+        'Either assetPath or icon must be provided');
     return Container(
       decoration: BoxDecoration(
         shape: BoxShape.circle,
@@ -128,7 +141,9 @@ class ImageList extends StatelessWidget {
       child: IconButton(
         icon: Transform.rotate(
           angle: rotation,
-          child: Image.asset(assetPath, height: 24, width: 24),
+          child: assetPath != null
+              ? Image.asset(assetPath, height: 24, width: 24)
+              : Icon(icon, size: 24, color: colorBlack),
         ),
         onPressed: onPressed,
         tooltip: tooltip,


### PR DESCRIPTION
Fixes #77

## Summary by Sourcery

Introduce a Quick LUT mode for faster image refresh by adding a UI toggle in the image editor and propagating a useQuickLut flag through the protocol and EPD driver.

New Features:
- Add a Quick Mode toggle button in the image editor toolbar with snackbar feedback to switch between normal and quick LUT processing.
- Enable quick LUT processing in the UC8253 driver by selecting the alternate waveform sequence when useQuickLut is true.
- Expose a useQuickLut parameter in Protocol.writeImages and Driver.init to propagate the quick mode setting.

Enhancements:
- Refactor the driver init and protocol method signatures to accept the optional useQuickLut flag.