### PR TITLE
chore: push only release APKs to the app branch

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -103,7 +103,7 @@ jobs:
           name: AAB Generated
           path: build/app/outputs/bundle
       
-      - name: Upload APK/AAB to apk branch
+      - name: Upload APK/AAB to app branch
         if: ${{ github.repository == 'fossasia/magic-epaper-app' }}
         run: |
           git config --global user.name "github-actions[bot]"
@@ -122,8 +122,8 @@ jobs:
 
           echo "Copying new build files"
 
-          find ../build/app/outputs/flutter-apk -type f \( -name '*.apk' -o -name '*.aab' \) -exec cp -v {} . \;
-          find ../build/app/outputs/bundle -type f \( -name '*.apk' -o -name '*.aab' \) -exec cp -v {} . \;
+          find ../build/app/outputs/flutter-apk -type f \( -name '*release.apk' -o -name '*.aab' \) -exec cp -v {} . \;
+          find ../build/app/outputs/bundle -type f \( -name '*release.apk' -o -name '*.aab' \) -exec cp -v {} . \;
 
           ls
 


### PR DESCRIPTION
## Summary by Sourcery

Update the GitHub Actions push workflow to target the app branch and restrict uploads to release APKs

CI:
- Rename the artifact upload step to push to app branch
- Filter copied APKs to include only release builds alongside AABs