### PR TITLE
feat: added clear all images functionality in image library.

### DIFF
--- a/lib/image_library/image_library.dart
+++ b/lib/image_library/image_library.dart
@@ -23,7 +23,7 @@ class ImageLibraryScreen extends StatefulWidget {
 class _ImageLibraryScreenState extends State<ImageLibraryScreen> {
   final TextEditingController _searchController = TextEditingController();
   bool _isDeleteMode = false;
-  Set<String> _selectedImages = <String>{};
+  final Set<String> _selectedImages = <String>{};
   late ImageOperationsService _operationsService;
 
   @override
@@ -127,7 +127,6 @@ class _ImageLibraryScreenState extends State<ImageLibraryScreen> {
   void _showClearAllDialog() {
     final provider = context.read<ImageLibraryProvider>();
     final totalImages = provider.savedImages.length;
-
 
     showDialog(
       context: context,

--- a/lib/image_library/image_library.dart
+++ b/lib/image_library/image_library.dart
@@ -4,6 +4,7 @@ import 'package:magicepaperapp/image_library/provider/image_library_provider.dar
 import 'package:magicepaperapp/image_library/services/image_operations_service.dart';
 import 'package:magicepaperapp/image_library/widgets/app_bar_widget.dart';
 import 'package:magicepaperapp/image_library/widgets/dialogs/batch_delete_confirmation_dialog.dart';
+import 'package:magicepaperapp/image_library/widgets/dialogs/clear_all_confirmation_dialog.dart';
 import 'package:magicepaperapp/image_library/widgets/dialogs/delete_confirmation_dialog.dart';
 import 'package:magicepaperapp/image_library/widgets/empty_state_widget.dart';
 import 'package:magicepaperapp/image_library/widgets/image_grid_widget.dart';
@@ -123,6 +124,21 @@ class _ImageLibraryScreenState extends State<ImageLibraryScreen> {
     });
   }
 
+  void _showClearAllDialog() {
+    final provider = context.read<ImageLibraryProvider>();
+    final totalImages = provider.savedImages.length;
+
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => ClearAllConfirmationDialog(
+        totalImages: totalImages,
+        onConfirm: () => _operationsService.clearAllData(provider),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -133,6 +149,7 @@ class _ImageLibraryScreenState extends State<ImageLibraryScreen> {
         onDeletePressed: _showBatchDeleteDialog,
         onExitDeleteMode: _exitDeleteMode,
         onEnterDeleteMode: _enterDeleteMode,
+        onClearAllPressed: _showClearAllDialog,
       ),
       body: Consumer<ImageLibraryProvider>(
         builder: (context, provider, child) {

--- a/lib/image_library/provider/image_library_provider.dart
+++ b/lib/image_library/provider/image_library_provider.dart
@@ -63,6 +63,33 @@ class ImageLibraryProvider extends ChangeNotifier {
     }
   }
 
+  Future<void> clearAllData() async {
+    try {
+      await _ensureInitialized();
+      await _initializeDirectories();
+      if (_imageDirectory != null && await _imageDirectory!.exists()) {
+        final files = await _imageDirectory!.list().toList();
+        for (final file in files) {
+          if (file is File) {
+            await file.delete();
+          }
+        }
+      }
+      if (_metadataFile != null && await _metadataFile!.exists()) {
+        await _metadataFile!.delete();
+      }
+      _savedImages.clear();
+      _searchQuery = '';
+      _selectedSource = 'all';
+
+      debugPrint('All data cleared successfully');
+      notifyListeners();
+    } catch (e) {
+      debugPrint('Error clearing all data: $e');
+      rethrow;
+    }
+  }
+
   Future<void> loadSavedImages() async {
     _isLoading = true;
     notifyListeners();

--- a/lib/image_library/services/image_operations_service.dart
+++ b/lib/image_library/services/image_operations_service.dart
@@ -48,6 +48,57 @@ class ImageOperationsService {
     }
   }
 
+  Future<void> clearAllData(ImageLibraryProvider provider) async {
+    try {
+      Navigator.pop(context);
+      _showClearAllLoadingSnackBar();
+      await provider.clearAllData();
+      _showClearAllSuccessSnackBar();
+    } catch (e) {
+      _showErrorSnackBar('Failed to clear all data: ${e.toString()}');
+    }
+  }
+
+  void _showClearAllSuccessSnackBar() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: const Row(
+          children: [
+            Icon(Icons.check_circle, color: Colors.white, size: 20),
+            SizedBox(width: 12),
+            Text('All data cleared successfully!'),
+          ],
+        ),
+        backgroundColor: Colors.green,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      ),
+    );
+  }
+
+  void _showClearAllLoadingSnackBar() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Row(
+          children: [
+            SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+            ),
+            SizedBox(width: 12),
+            Text('Clearing all data...'),
+          ],
+        ),
+        backgroundColor: Colors.orange,
+        duration: Duration(seconds: 2),
+      ),
+    );
+  }
+
   Future<void> batchDeleteImages(
     List<SavedImage> selectedImages,
     ImageLibraryProvider provider,

--- a/lib/image_library/widgets/app_bar_widget.dart
+++ b/lib/image_library/widgets/app_bar_widget.dart
@@ -7,6 +7,7 @@ class LibraryAppBar extends StatelessWidget implements PreferredSizeWidget {
   final VoidCallback onDeletePressed;
   final VoidCallback onExitDeleteMode;
   final VoidCallback onEnterDeleteMode;
+  final VoidCallback onClearAllPressed;
 
   const LibraryAppBar({
     super.key,
@@ -15,6 +16,7 @@ class LibraryAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.onDeletePressed,
     required this.onExitDeleteMode,
     required this.onEnterDeleteMode,
+    required this.onClearAllPressed,
   });
 
   @override
@@ -55,6 +57,79 @@ class LibraryAppBar extends StatelessWidget implements PreferredSizeWidget {
             icon: const Icon(Icons.delete),
             onPressed: onEnterDeleteMode,
             tooltip: 'Delete Mode',
+          ),
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_vert, color: Colors.white),
+            onSelected: (value) {
+              switch (value) {
+                case 'clear_all':
+                  onClearAllPressed();
+                  break;
+              }
+            },
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            color: Colors.white,
+            elevation: 8,
+            shadowColor: Colors.black.withOpacity(0.1),
+            offset: const Offset(0, 10),
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'clear_all',
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    color: Colors.red.withOpacity(0.05),
+                    border: Border.all(color: Colors.red.withOpacity(0.1)),
+                  ),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(6),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: const Icon(
+                          Icons.delete_forever_outlined,
+                          color: Colors.red,
+                          size: 18,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'Clear All Data',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                                color: Colors.black87,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              'Remove all images',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: Colors.grey.shade600,
+                                fontWeight: FontWeight.w400,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ),
         ],
       ],

--- a/lib/image_library/widgets/dialogs/clear_all_confirmation_dialog.dart
+++ b/lib/image_library/widgets/dialogs/clear_all_confirmation_dialog.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+
+class ClearAllConfirmationDialog extends StatelessWidget {
+  final VoidCallback onConfirm;
+  final int totalImages;
+
+  const ClearAllConfirmationDialog({
+    super.key,
+    required this.onConfirm,
+    required this.totalImages,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      child: SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.all(24),
+          margin: const EdgeInsets.symmetric(vertical: 48),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.1),
+                blurRadius: 20,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(),
+              const SizedBox(height: 24),
+              _buildDataSummary(),
+              const SizedBox(height: 24),
+              _buildActionButtons(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.red.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Icon(
+            Icons.delete_forever_outlined,
+            color: Colors.red,
+            size: 24,
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Clear All Data',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Complete data removal',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Colors.red.shade600,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDataSummary() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.red.withOpacity(0.05),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.red.withOpacity(0.2)),
+      ),
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.red.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.photo_library_outlined,
+                  size: 32,
+                  color: Colors.red.shade600,
+                ),
+                const SizedBox(width: 12),
+                Column(
+                  children: [
+                    Text(
+                      '$totalImages',
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.red.shade700,
+                      ),
+                    ),
+                    Text(
+                      'Total Images',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.red.shade600,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          const Text(
+            'All images and associated data will be permanently removed',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              color: Colors.black87,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionButtons(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton(
+            onPressed: () => Navigator.pop(context),
+            style: OutlinedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              side: BorderSide(color: Colors.grey.shade300),
+              foregroundColor: Colors.grey.shade700,
+            ),
+            child: const Text(
+              'Cancel',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: ElevatedButton(
+            onPressed: onConfirm,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              elevation: 0,
+            ),
+            child: const Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.delete_forever, size: 20),
+                SizedBox(width: 8),
+                Text(
+                  'Clear All',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Fixes: #82 

**Here is the demo video for clearing all images functionality from image library :** 

https://github.com/user-attachments/assets/d1be280b-20ce-48df-96c6-8f61f1bc5669

## Summary by Sourcery

Add a "Clear All Data" feature to the image library allowing users to remove all saved images at once

New Features:
- Add "Clear All Data" option in app bar overflow menu
- Introduce ClearAllConfirmationDialog displaying total images and confirming removal
- Extend ImageOperationsService with clearAllData method and show loading, success, and error snackbars
- Implement clearAllData in ImageLibraryProvider to delete all image files and metadata and reset library state