### PR TITLE
fix: upgraded pro_image_editor, updated background processing, locked canvas layer

### DIFF
--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -90,7 +90,6 @@ class _MovableBackgroundImageExampleState
     if (editor == null) return;
     for (final layer in layers) {
       if (layer.text != null) {
-        // Add as TextLayer
         editor.addLayer(
           TextLayer(
             textStyle: layer.textStyle,
@@ -113,7 +112,6 @@ class _MovableBackgroundImageExampleState
           blockSelectLayer: true,
         );
       } else if (layer.widget != null) {
-        // Add as WidgetLayer
         editor.addLayer(
           WidgetLayer(
             interaction: LayerInteraction(
@@ -427,12 +425,20 @@ class _MovableBackgroundImageExampleState
                   onAfterViewInit: () {
                     editorKey.currentState!.addLayer(
                       WidgetLayer(
+                        interaction: LayerInteraction(
+                          enableEdit: false,
+                          enableMove: false,
+                          enableRotate: false,
+                          enableScale: false,
+                          enableSelection: false,
+                        ),
                         offset: Offset.zero,
                         scale: _initScale,
                         widget: Image.asset(
                           ImageAssets.whiteBoard,
                           width: _canvasWidth,
                           height: _canvasHeight,
+                          fit: BoxFit.cover,
                           frameBuilder:
                               (context, child, frame, wasSynchronouslyLoaded) {
                             return AnimatedSwitcher(
@@ -466,28 +472,6 @@ class _MovableBackgroundImageExampleState
                     if (widget.initialLayers != null) {
                       addInitialLayers(widget.initialLayers!);
                     }
-                    //code testing
-                    //editorKey.currentState!.openTextEditor(initialText: "Hello World");
-                    // editorKey.currentState!.addLayer(
-                    //   TextLayer(
-                    //     align: TextAlign.left,
-                    //     offset: const Offset(0, -100),
-                    //     /// Add below
-                    //     color: Colors.black,
-                    //     background: Colors.white,
-                    //     colorMode: LayerBackgroundMode.backgroundAndColor,
-
-                    //     text: 'Hello World',
-                    //     interaction: LayerInteraction(
-                    //       enableEdit: true,
-                    //       enableMove: true,
-                    //       enableRotate: true,
-                    //       enableScale: true,
-                    //       enableSelection: true,
-                    //     ),
-                    //   ),
-                    //   blockSelectLayer: true,
-                    // );
                   },
                 ),
               ),
@@ -511,8 +495,7 @@ class _MovableBackgroundImageExampleState
                       return [
                         ReactiveWidget(
                           stream: rebuildStream,
-                          builder: (_) => editor.selectedLayerIndex >= 0 ||
-                                  editor.isSubEditorOpen
+                          builder: (_) => editor.isSubEditorOpen
                               ? const SizedBox.shrink()
                               : Positioned(
                                   bottom: 20,
@@ -551,7 +534,7 @@ class _MovableBackgroundImageExampleState
                     uiOverlayStyle: SystemUiOverlayStyle(
                       statusBarColor: Colors.black,
                     ),
-                    background: Colors.transparent,
+                    background: ui.Color.fromARGB(255, 155, 152, 152),
                   ),
                 ),
                 paintEditor: PaintEditorConfigs(
@@ -592,12 +575,9 @@ class _MovableBackgroundImageExampleState
                           ? MainAxisAlignment.spaceEvenly
                           : MainAxisAlignment.start),
                 ),
-
-                /// Crop-Rotate, Filter and Blur editors are not supported
                 cropRotateEditor: const CropRotateEditorConfigs(enabled: false),
                 filterEditor: const FilterEditorConfigs(enabled: false),
                 blurEditor: const BlurEditorConfigs(enabled: false),
-
                 stickerEditor: StickerEditorConfigs(
                   enabled: false,
                   initWidth:
@@ -605,9 +585,7 @@ class _MovableBackgroundImageExampleState
                               ? _editorSize.height
                               : _editorSize.width) /
                           _initScale,
-                  // ignore: deprecated_member_use
-                  buildStickers: (setLayer, scrollController) {
-                    // Optionally your code to pick layers
+                  builder: (setLayer, scrollController) {
                     return const SizedBox();
                   },
                 ),

--- a/lib/pro_image_editor/features/reorder_layer_example.dart
+++ b/lib/pro_image_editor/features/reorder_layer_example.dart
@@ -64,9 +64,12 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
       dragStartBehavior: DragStartBehavior.down,
       itemBuilder: (context, index) {
         Layer layer = widget.layers[index];
+        bool isFirstLayer = index == 0; // Canvas layer should not be movable
         return ListTile(
           key: ValueKey(layer),
-          tileColor: Theme.of(context).cardColor,
+          tileColor: isFirstLayer
+              ? Theme.of(context).disabledColor.withOpacity(0.1)
+              : Theme.of(context).cardColor,
           title: layer.runtimeType == TextLayer
               ? Text(
                   (layer as TextLayer).text,
@@ -98,7 +101,6 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
                                         item: layer.item,
                                         scale: layer.scale,
                                         enabledHitDetection: false,
-                                        freeStyleHighPerformance: false,
                                       ),
                                     ),
                             ),
@@ -115,10 +117,36 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
                           : Text(
                               layer.id.toString(),
                             ),
+          subtitle: isFirstLayer
+              ? const Text(
+                  'Canvas (Fixed)',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.grey,
+                    fontStyle: FontStyle.italic,
+                  ),
+                )
+              : null,
+          trailing: isFirstLayer
+              ? const Icon(
+                  Icons.lock,
+                  color: Colors.grey,
+                  size: 20,
+                )
+              : const Icon(
+                  Icons.drag_handle,
+                  color: Colors.grey,
+                ),
         );
       },
       itemCount: widget.layers.length,
-      onReorder: widget.onReorder,
+      onReorder: (oldIndex, newIndex) {
+        // Prevent moving the first layer (canvas)
+        if (oldIndex == 0 || newIndex == 0) {
+          return;
+        }
+        widget.onReorder(oldIndex, newIndex);
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   image_cropper: ^9.0.0
   app_settings: ^6.1.1
   fluttertoast: ^8.2.12
-  pro_image_editor: ^9.4.1
+  pro_image_editor: ^11.5.5
   gal: ^2.3.1
   file_saver: ^0.2.14
   bot_toast: ^4.1.3


### PR DESCRIPTION
Fixes: #177

## Summary by Sourcery

Upgrade pro_image_editor dependency and refine background and canvas layer behavior

Enhancements:
- Upgrade pro_image_editor to version 11.5.5
- Lock canvas layer interactions (disable edit, move, rotate, scale, selection) and apply BoxFit.cover to background image
- Set editor background color to ARGB(255,155,152,152) and disable crop, filter, and blur editors
- Prevent the first (canvas) layer from being reordered and visually indicate it as fixed in the layer list

Build:
- Bump pro_image_editor dependency in pubspec.yaml

Chores:
- Remove commented-out test code and redundant comments
- Update stickerEditor configuration to use builder callback instead of deprecated buildStickers