### PR TITLE
fix: Used FileSaver module for the export XBM feature and removed the MANAGE_EXTERNAL_STORAGE permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.NFC" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-feature android:name="android.hardware.nfc" android:required="true" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -165,6 +165,7 @@
   "language": "Language",
   "loading": "Loading...",
   "exportXbm": "Export XBM",
+  "exportingXbm": "Exporting XBM files...",
   "fullRefresh": "Full Refresh",
   "fullRefreshSelected": "Full Refresh Selected",
   "waveformSelected": "Selected",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1104,6 +1104,12 @@ abstract class AppLocalizations {
   /// **'Export XBM'**
   String get exportXbm;
 
+  /// No description provided for @exportingXbm.
+  ///
+  /// In en, this message translates to:
+  /// **'Exporting XBM files...'**
+  String get exportingXbm;
+
   /// No description provided for @fullRefresh.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -510,6 +510,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -510,6 +510,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -510,6 +510,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -510,6 +510,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -510,6 +510,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -510,6 +510,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -510,6 +510,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -510,6 +510,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -510,6 +510,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -510,6 +510,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -510,6 +510,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -510,6 +510,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -510,6 +510,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -510,6 +510,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get exportXbm => 'Export XBM';
 
   @override
+  String get exportingXbm => 'Exporting XBM files...';
+
+  @override
   String get fullRefresh => 'Full Refresh';
 
   @override

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:file_saver/file_saver.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:magicepaperapp/image_library/provider/image_library_provider.dart';
@@ -165,33 +164,33 @@ class _ImageEditorState extends State<ImageEditor> {
 
   Future<void> _exportXbmFiles() async {
     if (_rawImages.isEmpty) return;
+
     final now = DateTime.now();
     final timestamp =
         "${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}_${now.hour.toString().padLeft(2, '0')}-${now.minute.toString().padLeft(2, '0')}-${now.second.toString().padLeft(2, '0')}";
 
-    final magicEpaperDir = Directory('/storage/emulated/0/MagicEpaper');
-    if (!await magicEpaperDir.exists()) {
-      await magicEpaperDir.create(recursive: true);
-    }
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+      const SnackBar(
+        duration: Duration(seconds: 2),
+        content: Text('Exporting XBM files...'),
+      ),
+    );
 
-    final xbmDir = Directory('${magicEpaperDir.path}/XBM');
-    if (!await xbmDir.exists()) {
-      await xbmDir.create(recursive: true);
-    }
-
-    img.Image baseImage = _rawImages[_selectedFilterIndex];
-
-    if (flipHorizontal) {
-      baseImage = img.flipHorizontal(baseImage);
-    }
-    if (flipVertical) {
-      baseImage = img.flipVertical(baseImage);
-    }
-
-    final nonWhiteColors = widget.device.colors.where((c) => c != Colors.white);
-
-    var exportedCount = 0;
     try {
+      img.Image baseImage = _rawImages[_selectedFilterIndex];
+
+      if (flipHorizontal) {
+        baseImage = img.flipHorizontal(baseImage);
+      }
+      if (flipVertical) {
+        baseImage = img.flipVertical(baseImage);
+      }
+
+      final nonWhiteColors =
+          widget.device.colors.where((c) => c != Colors.white);
+
+      int exportedCount = 0;
       for (final color in nonWhiteColors) {
         final colorName = ColorUtils.getColorFileName(color);
         final variableName = 'image_$colorName';
@@ -203,27 +202,25 @@ class _ImageEditorState extends State<ImageEditor> {
 
         final xbmContent = XbmEncoder.encode(colorPlaneImage, variableName);
 
-        final file = File('${xbmDir.path}/${variableName}_$timestamp.xbm');
-        await file.writeAsString(xbmContent);
+        await FileSaver.instance.saveFile(
+          name: '${variableName}_$timestamp',
+          bytes: Uint8List.fromList(xbmContent.codeUnits),
+          fileExtension: 'xbm',
+          mimeType: MimeType.text,
+        );
         exportedCount++;
       }
-    } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
+
+      messenger.showSnackBar(
         SnackBar(
-          content: Text('${appLocalizations.exportFailed}: $e'),
+          content: Text(
+              '${appLocalizations.exported} $exportedCount ${appLocalizations.xbmFilesToMagicEpaper}'),
         ),
       );
-      return;
+    } catch (e) {
+      messenger.showSnackBar(
+          SnackBar(content: Text('${appLocalizations.exportFailed}: $e')));
     }
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        duration: const Duration(seconds: 2),
-        content: Text(
-          '${appLocalizations.exported} $exportedCount ${appLocalizations.xbmFilesToMagicEpaper}',
-        ),
-      ),
-    );
   }
 
   @override

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -171,9 +171,9 @@ class _ImageEditorState extends State<ImageEditor> {
 
     final messenger = ScaffoldMessenger.of(context);
     messenger.showSnackBar(
-      const SnackBar(
-        duration: Duration(seconds: 2),
-        content: Text('Exporting XBM files...'),
+      SnackBar(
+        duration: const Duration(seconds: 2),
+        content: Text(appLocalizations.exportingXbm),
       ),
     );
 

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>


### PR DESCRIPTION
Fixes: #187 

@Dhruv1797 will also create a PR for fixing Issue 187, he will fix the image library feature to not use the MANAGE_EXTERNAL_STORAGE permission

## Summary by Sourcery

Switch XBM file export to use the FileSaver plugin with user feedback, remove direct external storage permissions, and update platform entitlements and localizations.

New Features:
- Show a temporary "Exporting XBM files..." snackbar during the export process

Bug Fixes:
- Remove READ/WRITE_EXTERNAL_STORAGE and MANAGE_EXTERNAL_STORAGE permissions from AndroidManifest

Enhancements:
- Replace direct dart:io file writes with FileSaver for cross-platform file export
- Add iOS Info.plist entries to enable in-place document opening and file sharing

Documentation:
- Add a new "exportingXbm" localization key across all supported locales