### PR TITLE
fix: Removed QUERY_ALL_PACKAGES Permission

### DIFF
--- a/lib/ndef_screen/app_launcher_card.dart
+++ b/lib/ndef_screen/app_launcher_card.dart
@@ -54,7 +54,7 @@ class _AppLauncherCardState extends State<AppLauncherCard> {
   Future<void> _loadApps() async {
     setState(() => _isLoading = true);
     try {
-      final apps = await AppLauncherService.getInstalledApps();
+      final apps = await AppLauncherService.getCommonApps();
       setState(() {
         _allApps = apps;
         _filteredApps = apps;
@@ -86,10 +86,7 @@ class _AppLauncherCardState extends State<AppLauncherCard> {
       return;
     }
 
-    final customApp = AppData(
-      appName: 'Custom: $packageName',
-      packageName: packageName,
-    );
+    final customApp = AppLauncherService.createCustomApp(packageName);
     widget.onAppSelected(customApp);
     _customPackageController.clear();
     setState(() => _showCustomInput = false);

--- a/lib/ndef_screen/app_launcher_card.dart
+++ b/lib/ndef_screen/app_launcher_card.dart
@@ -51,10 +51,10 @@ class _AppLauncherCardState extends State<AppLauncherCard> {
     super.dispose();
   }
 
-  Future<void> _loadApps() async {
+  void _loadApps() {
     setState(() => _isLoading = true);
     try {
-      final apps = await AppLauncherService.getCommonApps();
+      final apps = AppLauncherService.getCommonApps();
       setState(() {
         _allApps = apps;
         _filteredApps = apps;

--- a/lib/ndef_screen/app_nfc/app_selection_service.dart
+++ b/lib/ndef_screen/app_nfc/app_selection_service.dart
@@ -18,7 +18,7 @@ class AppLauncherService {
     AppData(appName: 'Settings', packageName: 'com.android.settings'),
   ];
 
-  static Future<List<AppData>> getCommonApps() async {
+  static List<AppData> getCommonApps() {
     final apps = List<AppData>.from(_commonApps);
     apps.sort((a, b) => a.appName.compareTo(b.appName));
     return apps;

--- a/lib/ndef_screen/app_nfc/app_selection_service.dart
+++ b/lib/ndef_screen/app_nfc/app_selection_service.dart
@@ -1,48 +1,34 @@
-import 'package:flutter/material.dart';
-import 'package:installed_apps/installed_apps.dart';
-import 'package:installed_apps/app_info.dart';
 import 'package:magicepaperapp/ndef_screen/app_nfc/app_data_model.dart';
 
 class AppLauncherService {
-  static List<AppData> _cachedApps = [];
+  static final List<AppData> _commonApps = [
+    AppData(appName: 'Chrome', packageName: 'com.android.chrome'),
+    AppData(appName: 'Gmail', packageName: 'com.google.android.gm'),
+    AppData(appName: 'YouTube', packageName: 'com.google.android.youtube'),
+    AppData(appName: 'WhatsApp', packageName: 'com.whatsapp'),
+    AppData(appName: 'Instagram', packageName: 'com.instagram.android'),
+    AppData(appName: 'Facebook', packageName: 'com.facebook.katana'),
+    AppData(appName: 'Twitter', packageName: 'com.twitter.android'),
+    AppData(appName: 'Spotify', packageName: 'com.spotify.music'),
+    AppData(appName: 'Netflix', packageName: 'com.netflix.mediaclient'),
+    AppData(appName: 'Uber', packageName: 'com.ubercab'),
+    AppData(appName: 'Maps', packageName: 'com.google.android.apps.maps'),
+    AppData(
+        appName: 'Calculator', packageName: 'com.google.android.calculator'),
+    AppData(appName: 'Settings', packageName: 'com.android.settings'),
+  ];
 
-  static Future<List<AppData>> getInstalledApps(
-      {bool includeIcons = true}) async {
-    if (_cachedApps.isNotEmpty) {
-      return _cachedApps;
-    }
-    try {
-      final List<AppInfo> apps = await InstalledApps.getInstalledApps(
-        true,
-        includeIcons,
-        "",
-      );
-
-      _cachedApps = apps
-          .where((app) => app.packageName.isNotEmpty && app.name.isNotEmpty)
-          .map((app) => AppData(
-                appName: app.name,
-                packageName: app.packageName,
-                icon: app.icon,
-              ))
-          .toList();
-
-      _cachedApps.sort((a, b) => a.appName.compareTo(b.appName));
-      return _cachedApps;
-    } catch (e) {
-      debugPrint('Error getting installed apps: $e');
-    }
-    return [];
+  static Future<List<AppData>> getCommonApps() async {
+    final apps = List<AppData>.from(_commonApps);
+    apps.sort((a, b) => a.appName.compareTo(b.appName));
+    return apps;
   }
 
-  static List<AppData> searchApps(List<AppData> apps, String query) {
-    if (query.isEmpty) return apps;
-    final lowercaseQuery = query.toLowerCase();
-    return apps
-        .where((app) =>
-            app.appName.toLowerCase().contains(lowercaseQuery) ||
-            app.packageName.toLowerCase().contains(lowercaseQuery))
-        .toList();
+  static AppData createCustomApp(String packageName, {String? customName}) {
+    return AppData(
+      appName: customName ?? 'Custom: $packageName',
+      packageName: packageName,
+    );
   }
 
   static bool isValidPackageName(String packageName) {
@@ -56,5 +42,15 @@ class AppLauncherService {
     return packageName.split('.').every((segment) =>
         segment.isNotEmpty &&
         RegExp(r'^[a-zA-Z][a-zA-Z0-9_]*$').hasMatch(segment));
+  }
+
+  static List<AppData> searchApps(List<AppData> apps, String query) {
+    if (query.isEmpty) return apps;
+    final lowercaseQuery = query.toLowerCase();
+    return apps
+        .where((app) =>
+            app.appName.toLowerCase().contains(lowercaseQuery) ||
+            app.packageName.toLowerCase().contains(lowercaseQuery))
+        .toList();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,6 @@ dependencies:
   path: ^1.9.1
   permission_handler: ^12.0.1
   ndef: ^0.3.1
-  installed_apps: ^1.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes : #212 

Removed Package installed_apps , which used the QUERY_ALL_PACKAGES Permission.
Now replaced the app selection with some common apps and also an option to export custom app package name

## Summary by Sourcery

Replace dynamic installed-apps lookup with a predefined list of common apps and a custom package input to eliminate the QUERY_ALL_PACKAGES permission requirement

New Features:
- Provide a fixed list of common apps for selection
- Allow exporting a custom app by entering its package name

Bug Fixes:
- Remove QUERY_ALL_PACKAGES permission by dropping the installed_apps dependency

Enhancements:
- Refactor AppLauncherService to use a static common apps list and a createCustomApp method

Build:
- Remove installed_apps from pubspec.yaml