### PR TITLE
feat: Added logic to change language

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:magicepaperapp/image_library/provider/image_library_provider.dar
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
 import 'package:magicepaperapp/provider/image_loader.dart';
+import 'package:magicepaperapp/provider/locale_provider.dart';
 import 'package:magicepaperapp/view/about_us_screen.dart';
 import 'package:magicepaperapp/view/buy_badge_screen.dart';
 import 'package:magicepaperapp/view/settings_screen.dart';
@@ -12,13 +13,13 @@ import 'package:magicepaperapp/ndef_screen/nfc_write_screen.dart';
 import 'package:magicepaperapp/view/display_selection_screen.dart';
 
 void main() {
-  /// Sets up the GetIt service locator for dependency injection.
   setupLocator();
   runApp(
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (context) => ImageLoader()),
         ChangeNotifierProvider(create: (_) => ImageLibraryProvider()),
+        ChangeNotifierProvider(create: (_) => LocaleProvider()),
       ],
       child: const MyApp(),
     ),
@@ -30,35 +31,32 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Magic ePaper',
-
-      /// Delegates for handling localization.
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-
-      builder: (context, child) {
-        /// Registers the AppLocalizations instance with the service locator
-        /// to make it accessible throughout the app without a BuildContext.
-        registerAppLocalizations(AppLocalizations.of(context)!);
-        return child!;
+    return Consumer<LocaleProvider>(
+      builder: (context, localeProvider, child) {
+        return MaterialApp(
+          title: 'Magic ePaper',
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: localeProvider.locale,
+          builder: (context, child) {
+            registerAppLocalizations(AppLocalizations.of(context)!);
+            return child!;
+          },
+          initialRoute: '/',
+          routes: {
+            '/': (context) => const DisplaySelectionScreen(),
+            '/aboutUs': (context) => const AboutUsScreen(),
+            '/buyBadge': (context) => const BuyBadgeScreen(),
+            '/settings': (context) => const SettingsScreen(),
+            '/nfcReadScreen': (context) => const NFCReadScreen(),
+            '/nfcWriteScreen': (context) => const NFCWriteScreen(),
+          },
+          theme: ThemeData(
+            primarySwatch: Colors.blue,
+            visualDensity: VisualDensity.adaptivePlatformDensity,
+          ),
+        );
       },
-
-      initialRoute: '/',
-
-      routes: {
-        '/': (context) => const DisplaySelectionScreen(),
-        '/aboutUs': (context) => const AboutUsScreen(),
-        '/buyBadge': (context) => const BuyBadgeScreen(),
-        '/settings': (context) => const SettingsScreen(),
-        '/nfcReadScreen': (context) => const NFCReadScreen(),
-        '/nfcWriteScreen': (context) => const NFCWriteScreen(),
-      },
-
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      ),
     );
   }
 }

--- a/lib/provider/locale_provider.dart
+++ b/lib/provider/locale_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// A provider class for managing the application's locale.
+///
+/// This class extends [ChangeNotifier] to allow widgets to listen for
+/// changes in the locale and rebuild accordingly.
+class LocaleProvider with ChangeNotifier {
+  Locale _locale = const Locale('en');
+
+  Locale get locale => _locale;
+
+  /// Sets the application's locale.
+  ///
+  /// When the locale is changed, it notifies all listening widgets to rebuild.
+  void setLocale(Locale newLocale) {
+    _locale = newLocale;
+    notifyListeners();
+  }
+}

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -63,7 +63,6 @@ class SettingsScreenState extends State<SettingsScreen> {
                   onChanged: (Locale? newLocale) {
                     if (newLocale != null) {
                       localeProvider.setLocale(newLocale);
-                      print('Locale changed to: ${newLocale.languageCode}');
                     }
                   },
                   items: [

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
-//import 'package:flutter/services.dart';
 import 'package:magicepaperapp/constants/color_constants.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
+import 'package:magicepaperapp/provider/locale_provider.dart';
+import 'package:provider/provider.dart';
 import 'package:magicepaperapp/util/orientation_util.dart';
 import 'package:magicepaperapp/view/widget/common_scaffold_widget.dart';
 
 AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
-//TODO add Language Support and Dark mode support here
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
 
@@ -17,18 +17,26 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class SettingsScreenState extends State<SettingsScreen> {
-  String selectedLanguage = 'ENGLISH';
-
-  final List<String> languages = ['ENGLISH', 'CHINESE'];
-
   @override
   void initState() {
     setPortraitOrientation();
     super.initState();
   }
 
+  String _getLanguageName(Locale locale) {
+    switch (locale.languageCode) {
+      case 'hi':
+        return 'हिंदी (Beta - Partial Translation)';
+      case 'en':
+      default:
+        return 'English';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final localeProvider = Provider.of<LocaleProvider>(context);
+
     return CommonScaffold(
       index: 4,
       body: Padding(
@@ -48,23 +56,32 @@ class SettingsScreenState extends State<SettingsScreen> {
               ),
               padding: const EdgeInsets.symmetric(horizontal: 12),
               child: DropdownButtonHideUnderline(
-                child: DropdownButton<String>(
-                  value: selectedLanguage,
+                child: DropdownButton<Locale>(
+                  value: localeProvider.locale,
                   isExpanded: true,
                   icon: const Icon(Icons.arrow_drop_down, color: mdGrey400),
-                  onChanged: (String? newValue) {
-                    setState(() {
-                      selectedLanguage = newValue!;
-                    });
+                  onChanged: (Locale? newLocale) {
+                    if (newLocale != null) {
+                      localeProvider.setLocale(newLocale);
+                      print('Locale changed to: ${newLocale.languageCode}');
+                    }
                   },
-                  items:
-                      languages.map<DropdownMenuItem<String>>((String value) {
-                    return DropdownMenuItem<String>(
-                      value: value,
-                      child: Text(value,
-                          style: const TextStyle(color: colorBlack)),
-                    );
-                  }).toList(),
+                  items: [
+                    DropdownMenuItem<Locale>(
+                      value: const Locale('en'),
+                      child: Text(
+                        _getLanguageName(const Locale('en')),
+                        style: const TextStyle(color: colorBlack),
+                      ),
+                    ),
+                    DropdownMenuItem<Locale>(
+                      value: const Locale('hi'),
+                      child: Text(
+                        _getLanguageName(const Locale('hi')),
+                        style: const TextStyle(color: colorBlack),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary by Sourcery

Add support for dynamic language switching by introducing a LocaleProvider and wiring it into the app and settings UI

New Features:
- Enable runtime locale switching between English and Hindi via the settings screen

Enhancements:
- Introduce LocaleProvider to manage and notify locale changes and register it in MultiProvider
- Configure MaterialApp to consume LocaleProvider and apply its locale
- Update SettingsScreen to present a locale dropdown and invoke LocaleProvider on selection