### PR TITLE
Fix: Selecting a badge is delayed after the user taps.

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -574,5 +574,6 @@
   "productImageSelected": "Product Image Selected",
   "selectProductImage": "Select Product Image",
   "tapToChangeImage": "Tap to change image",
-  "chooseImageFromGallery": "Choose image from gallery"
+  "chooseImageFromGallery": "Choose image from gallery",
+  "processingImages": "Processing images..."
 }

--- a/lib/view/display_selection_screen.dart
+++ b/lib/view/display_selection_screen.dart
@@ -88,11 +88,23 @@ class _DisplaySelectionScreenState extends State<DisplaySelectionScreen> {
 
                       Navigator.push(
                         context,
-                        MaterialPageRoute(
-                          builder: (context) => ImageEditor(
-                            isExportOnly: false,
-                            device: displays[index],
+                        PageRouteBuilder(
+                          pageBuilder:
+                              (context, animation, secondaryAnimation) =>
+                                  _LoadingWrapper(
+                            child: ImageEditor(
+                              isExportOnly: false,
+                              device: displays[index],
+                            ),
                           ),
+                          transitionsBuilder:
+                              (context, animation, secondaryAnimation, child) {
+                            return FadeTransition(
+                              opacity: animation,
+                              child: child,
+                            );
+                          },
+                          transitionDuration: const Duration(milliseconds: 300),
                         ),
                       );
                     },
@@ -104,5 +116,58 @@ class _DisplaySelectionScreenState extends State<DisplaySelectionScreen> {
         );
       },
     );
+  }
+}
+
+class _LoadingWrapper extends StatefulWidget {
+  final Widget child;
+
+  const _LoadingWrapper({required this.child});
+
+  @override
+  State<_LoadingWrapper> createState() => _LoadingWrapperState();
+}
+
+class _LoadingWrapperState extends State<_LoadingWrapper> {
+  bool _showLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Future.delayed(const Duration(milliseconds: 50), () {
+        if (mounted) {
+          setState(() {
+            _showLoading = false;
+          });
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_showLoading) {
+      return Scaffold(
+        backgroundColor: Colors.white,
+        body: const Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF2196F3)),
+              ),
+              SizedBox(height: 16),
+              Text(
+                'Loading...',
+                style: TextStyle(color: Colors.black, fontSize: 14),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return widget.child;
   }
 }


### PR DESCRIPTION
Fixes: #202 

**Here is the demo video of the updated behavior:** 

https://github.com/user-attachments/assets/f4c00c6c-97a7-42fc-86f9-b7f8aaf603e9

## Summary by Sourcery

Improve image editor responsiveness by moving heavy image processing off the UI thread, showing proper loading indicators, and smoothing navigation with a fade transition and temporary loading screen

New Features:
- Introduce a fade transition and temporary loading wrapper when navigating to the image editor

Bug Fixes:
- Fix tap responsiveness by deferring initial and filter selection image processing until after the first frame

Enhancements:
- Process images asynchronously with micro-delays and state flags to maintain UI responsiveness
- Replace static loading text with a CircularProgressIndicator and dynamic status messages during initialization, loading, and processing
- Add error handling around initial and default image loading to surface failures