### PR TITLE
fixed: reorder layer bug

### DIFF
--- a/lib/pro_image_editor/features/reorder_layer_example.dart
+++ b/lib/pro_image_editor/features/reorder_layer_example.dart
@@ -145,6 +145,10 @@ class _ReorderLayerSheetState extends State<ReorderLayerSheet> {
         if (oldIndex == 0 || newIndex == 0) {
           return;
         }
+
+        if (oldIndex < newIndex) {
+          newIndex -= 1;
+        }
         widget.onReorder(oldIndex, newIndex);
       },
     );


### PR DESCRIPTION
Fixes: #255 - Reorder Layer functionality fails with null check error when dragging items downward

Added index adjustment logic in the onReorder callback

Screen Record:

https://github.com/user-attachments/assets/8b52e416-d34f-4ca4-bf64-2e961168a435

## Summary by Sourcery

Bug Fixes:
- Adjust newIndex when reordering items downward to avoid off-by-one null-check errors