### PR TITLE
Fix center text in library

### DIFF
--- a/lib/image_library/widgets/dialogs/storage_permisson_dialog.dart
+++ b/lib/image_library/widgets/dialogs/storage_permisson_dialog.dart
@@ -83,7 +83,7 @@ class StoragePermissionDialog extends StatelessWidget {
                       'Cancel',
                       style: TextStyle(
                         color: Colors.grey,
-                        fontSize: 19,
+                        fontSize: 16,
                         fontWeight: FontWeight.w500,
                       ),
                     ),
@@ -109,7 +109,7 @@ class StoragePermissionDialog extends StatelessWidget {
                       'Grant Permission',
                       textAlign: TextAlign.center,
                       style: TextStyle(
-                        fontSize: 19,
+                        fontSize: 16,
                         fontWeight: FontWeight.w600,
                       ),
                     ),


### PR DESCRIPTION
Fixes: #240 

Here is the updated version: 
![WhatsApp Image 2025-10-14 at 12 17 37 AM](https://github.com/user-attachments/assets/352c3aa4-af88-442d-b0f0-a327398e861a)

## Summary by Sourcery

Bug Fixes:
- Add TextAlign.center to the 'Grant Permission' button text.