### PR TITLE
Fix : Remove Dead Code

### DIFF
--- a/lib/ndef_screen/controller/nfc_controller.dart
+++ b/lib/ndef_screen/controller/nfc_controller.dart
@@ -91,20 +91,7 @@ class NFCController extends ChangeNotifier {
     }
   }
 
-  // Future<void> writeAppLauncherRecord(String packageName,
-  //     {String? appUri}) async {
-  //   if (_availability != NFCAvailability.available ||
-  //       packageName.trim().isEmpty) {
-  //     return;
-  //   }
-  //   try {
-  //     final records = NDEFRecordFactory.createAppLauncherRecords(packageName,
-  //         appUri: appUri);
-  //     await _performWrite(records);
-  //   } catch (e) {
-  //     _setResult('${StringConstants.errorCreatingAppRecord}$e');
-  //   }
-  // }
+
 
   Future<void> writeMultipleRecords(String text, String url, String wifiSSID,
       String wifiPassword, VCardData? vCardData) async {

--- a/lib/ndef_screen/controller/nfc_controller.dart
+++ b/lib/ndef_screen/controller/nfc_controller.dart
@@ -91,8 +91,6 @@ class NFCController extends ChangeNotifier {
     }
   }
 
-
-
   Future<void> writeMultipleRecords(String text, String url, String wifiSSID,
       String wifiPassword, VCardData? vCardData) async {
     if (_availability != NFCAvailability.available) return;


### PR DESCRIPTION
- **Location**: `lib/ndef_screen/controller/nfc_controller.dart`
- **Description**: There is a block of commented-out code (lines 94-107) that duplicates the `writeAppLauncherRecord` method.
- **Action**: Delete the commented-out code to keep the codebase clean.

## Summary by Sourcery

Enhancements:
- Clean up the NFC controller by deleting a duplicated, commented-out writeAppLauncherRecord method.