### PR TITLE
fix: align text and icon in Write NFC Tags

### DIFF
--- a/lib/ndef_screen/widgets/nfc_write_card.dart
+++ b/lib/ndef_screen/widgets/nfc_write_card.dart
@@ -332,6 +332,7 @@ class _NFCWriteCardState extends State<NFCWriteCard> {
     return TextField(
       onChanged: onChanged,
       maxLines: maxLines,
+      minLines: 1,
       obscureText: obscureText,
       style: const TextStyle(fontSize: 14),
       decoration: InputDecoration(


### PR DESCRIPTION
Fixes #246 

### Changes made:
- Added minLines: 1 so the field renders as a single-line input by default
- Ensured the field expands to a second line only when the user types

### Screenshots:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/76fa1c44-98ca-4ff4-b3cf-99e79eb6d42d" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b86c9c7b-38d0-4034-8e7b-becbf87319b8" />
