### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,60 @@
+## 📌 Description
+Please include a clear and concise description of what this pull request does.
+
+Fixes # (issue number, if applicable)
+
+---
+
+## 🛠️ Type of Change
+Please mark the relevant option(s):
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
+- [ ] ✨ New feature (non-breaking change which adds functionality)
+- [ ] 🧹 Refactor / Cleanup (no functional change)
+- [ ] 📝 Documentation update
+- [ ] ⚙️ CI / Build / Configuration change
+
+---
+
+## ✅ What was changed
+Describe the changes made in this PR:
+- 
+- 
+- 
+
+---
+
+## 🧪 How was this tested?
+Please describe how you tested your changes:
+- [ ] Tested on Android
+- [ ] Tested on iOS
+- [ ] Tested on Web
+- [ ] Manual testing
+- [ ] Unit tests (if applicable)
+
+Explain briefly:
+- 
+- 
+
+---
+
+## 📸 Screenshots / Recordings
+If applicable, add screenshots or screen recordings to help reviewers understand the change.
+
+> Tip: You can drag & drop images directly here.
+
+---
+
+## 📋 Checklist
+Please confirm the following:
+
+- [ ] My code follows the project’s coding style
+- [ ] I have run `flutter analyze` and fixed warnings/errors
+- [ ] I have tested the changes locally
+- [ ] I have linked the relevant issue (if applicable)
+- [ ] I have not added unnecessary files or changes
+
+---
+
+##  Additional Notes
+Add any additional context, concerns, or questions for the reviewers.


### PR DESCRIPTION
Fixes: (none)

## Summary
Adds a standardized pull request template to improve PR quality, make reviews faster, and help contributors provide complete context (what/why/how-tested).

## Changes
- Added `.github/pull_request_template.md` with sections for:
  - Summary
  - What changed
  - How tested
  - Screenshots / recordings
  - Checklist

## Why this change
This repository currently does not provide a PR template, so contributors often miss important details (steps to test, screenshots, checklist), which slows down reviews. A template makes contributions consistent and maintainer-friendly.

## Summary by Sourcery

Documentation:
- Introduce a GitHub pull request template with sections for description, change type, testing, screenshots, checklist, and additional notes.