### PR TITLE
chore(deps): bump pro_image_editor to 11.17.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -448,7 +448,7 @@ packages:
     source: hosted
     version: "0.2.2"
   integration_test:
-    dependency: "direct dev"
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -501,7 +501,7 @@ packages:
     source: hosted
     version: "6.0.0"
   logger:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: logger
       sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
@@ -565,7 +565,7 @@ packages:
     source: hosted
     version: "2.0.0"
   mobile_scanner:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: mobile_scanner
       sha256: c6184bf2913dd66be244108c9c27ca04b01caf726321c44b0e7a7a1e32d41044
@@ -736,10 +736,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: "27a93dfef2fd7d9894deed71b12d6c95a1bf94a06c8a588419ef4d5e2b8f6034"
+      sha256: c186bf0b2a8debda3df8ba1fae51c9c75f19fc921a492a985593cc29f9a6e93c
       url: "https://pub.dev"
     source: hosted
-    version: "11.22.2"
+    version: "11.15.1"
   process:
     dependency: transitive
     description:
@@ -1082,5 +1082,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.38.5"
+  dart: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.8"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -448,7 +448,7 @@ packages:
     source: hosted
     version: "0.2.2"
   integration_test:
-    dependency: transitive
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -501,7 +501,7 @@ packages:
     source: hosted
     version: "6.0.0"
   logger:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logger
       sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
@@ -565,7 +565,7 @@ packages:
     source: hosted
     version: "2.0.0"
   mobile_scanner:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mobile_scanner
       sha256: c6184bf2913dd66be244108c9c27ca04b01caf726321c44b0e7a7a1e32d41044
@@ -736,10 +736,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: c186bf0b2a8debda3df8ba1fae51c9c75f19fc921a492a985593cc29f9a6e93c
+      sha256: "27a93dfef2fd7d9894deed71b12d6c95a1bf94a06c8a588419ef4d5e2b8f6034"
       url: "https://pub.dev"
     source: hosted
-    version: "11.15.1"
+    version: "11.22.2"
   process:
     dependency: transitive
     description:
@@ -1082,5 +1082,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.8"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.38.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   image_cropper: ^11.0.0
   app_settings: ^7.0.0
   fluttertoast: ^9.0.0
-  pro_image_editor: ^11.15.1
+  pro_image_editor: ^11.17.0
   gal: ^2.3.1
   file_saver: ^0.3.1
   bot_toast: ^4.1.3


### PR DESCRIPTION
Updates pro_image_editor dependency to 11.17.0.

This release includes the hexagon drag-to-draw consistency fix
that was merged upstream in hm21/pro_image_editor#738.

No direct functional changes are introduced in Magic ePaper;
the update simply pulls in the upstream fix.

## Summary by Sourcery

Build:
- Bump pro_image_editor package version from 11.15.1 to 11.17.0 in pubspec configuration.