### PR TITLE
fix: resolve undefined localization getters in image_editor

### DIFF
--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -20,9 +20,7 @@ import 'package:magicepaperapp/util/epd/epd.dart';
 import 'package:magicepaperapp/constants/color_constants.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import '../util/app_logger.dart';
-import 'package:magicepaperapp/provider/getitlocator.dart';
 
-AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
 class ImageEditor extends StatefulWidget {
   final DisplayDevice device;
@@ -311,7 +309,7 @@ class _ImageEditorState extends State<ImageEditor> {
               style: TextButton.styleFrom(
                 foregroundColor: colorAccent,
               ),
-              child: const Text('OK'),
+              child: Text(appLocalizations.ok),
             ),
           ],
         );
@@ -321,6 +319,7 @@ class _ImageEditorState extends State<ImageEditor> {
 
   @override
   Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
     var imgLoader = context.watch<ImageLoader>();
     if (!_isInitializing && imgLoader.image != null && !_isProcessingImages) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -578,6 +577,7 @@ class BottomActionMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+     final appLocalizations = AppLocalizations.of(context)!;
     return SafeArea(
       top: false,
       bottom: true,
@@ -602,7 +602,7 @@ class BottomActionMenu extends StatelessWidget {
               _buildActionButton(
                 context: context,
                 icon: Icons.add_photo_alternate_outlined,
-                label: "Import",
+                label: appLocalizations.importImageButtonLabel,
                 onTap: () async {
                   final success = await imgLoader.pickImage(
                     width: epd.width,
@@ -646,7 +646,7 @@ class BottomActionMenu extends StatelessWidget {
               _buildActionButton(
                 context: context,
                 icon: Icons.text_fields,
-                label: "Text",
+                label: appLocalizations.textPrefix,
                 onTap: () async {
                   final bytes = await Navigator.of(context).push<Uint8List>(
                     MaterialPageRoute(


### PR DESCRIPTION
Description
The image_editor.dart file is throwing compilation errors because it attempts to access localized strings that do not exist in the generated AppLocalizations class. This typically happens if the keys are missing from the .arb files or if the localization generation step hasn't been run.

Error Details

File: lib/view/image_editor.dart

Errors:
Line 606: The getter 'import' isn't defined for the type 'AppLocalizations'.
Line 650: The getter 'text' isn't defined for the type 'AppLocalizations'.

Steps to Reproduce

Open lib/view/image_editor.dart.
Observe the red linting/errors on calls to AppLocalizations.of(context)!.import and AppLocalizations.of(context)!.text.

