### PR TITLE
Fix: localize text editor title

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -581,5 +581,6 @@
   "fullRefreshDescription": "Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.",
   "partialRefreshInfo": "Partial Refresh (Waveforms)",
   "partialRefreshDescription": "Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.",
-  "longPressForInfo": "Long press for more information"
+  "longPressForInfo": "Long press for more information",
+  "textEditorTitle": "Text Editor"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -115,6 +115,7 @@ abstract class AppLocalizations {
     Locale('id'),
     Locale('ja'),
     Locale('nb'),
+    Locale('nb', 'NO'),
     Locale('pt'),
     Locale('pt', 'BR'),
     Locale('ru'),
@@ -2694,6 +2695,14 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
 
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
+    case 'nb':
+      {
+        switch (locale.countryCode) {
+          case 'NO':
+            return AppLocalizationsNbNo();
+        }
+        break;
+      }
     case 'pt':
       {
         switch (locale.countryCode) {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -115,7 +115,6 @@ abstract class AppLocalizations {
     Locale('id'),
     Locale('ja'),
     Locale('nb'),
-    Locale('nb', 'NO'),
     Locale('pt'),
     Locale('pt', 'BR'),
     Locale('ru'),
@@ -2597,6 +2596,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Choose image from gallery'**
   String get chooseImageFromGallery;
+
+  /// No description provided for @processingImages.
+  ///
+  /// In en, this message translates to:
+  /// **'Processing images...'**
+  String get processingImages;
+
+  /// No description provided for @refreshModeInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh Mode Information'**
+  String get refreshModeInfo;
+
+  /// No description provided for @fullRefreshInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Full Refresh'**
+  String get fullRefreshInfo;
+
+  /// No description provided for @fullRefreshDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.'**
+  String get fullRefreshDescription;
+
+  /// No description provided for @partialRefreshInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Partial Refresh (Waveforms)'**
+  String get partialRefreshInfo;
+
+  /// No description provided for @partialRefreshDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.'**
+  String get partialRefreshDescription;
+
+  /// No description provided for @longPressForInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Long press for more information'**
+  String get longPressForInfo;
+
+  /// No description provided for @textEditorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Text Editor'**
+  String get textEditorTitle;
 }
 
 class _AppLocalizationsDelegate
@@ -2647,14 +2694,6 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
 
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'nb':
-      {
-        switch (locale.countryCode) {
-          case 'NO':
-            return AppLocalizationsNbNo();
-        }
-        break;
-      }
     case 'pt':
       {
         switch (locale.countryCode) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -16,10 +16,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'Magic ePaper is an app designed to control and update ePaper displays. The goal is to provide tools for customizing and transferring images, text, and patterns to ePaper screens using NFC. Data transfer from the smartphone to the ePaper hardware is done wirelessly via NFC. The project is built on top of custom firmware and display drivers for seamless communication and efficient image rendering.';
 
   @override
-  String get developedBy => 'Developed by';
+  String get developedBy => 'פותח על ידי';
 
   @override
-  String get fossasiaContributors => 'FOSSASIA contributors';
+  String get fossasiaContributors => 'מתנדבי FOSSASIA';
 
   @override
   String get contactWithUs => 'Contact With Us';
@@ -51,7 +51,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings => 'Settings';
 
   @override
-  String get aboutUs => 'About Us';
+  String get aboutUs => 'עלינו';
 
   @override
   String get other => 'Other';
@@ -87,7 +87,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get filterScreenTitle => 'Select a Filter';
 
   @override
-  String get scanningForNfcTag => 'Scanning for NFC tag...';
+  String get scanningForNfcTag => 'מתבצעת סריקה לאיתור תג NFC…';
 
   @override
   String get scanningForNfcTagToWrite => 'Scanning for NFC tag to write...';
@@ -181,7 +181,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get absoluteUriPrefix => 'Absolute URI: ';
 
   @override
-  String get rawPrefix => 'Raw: ';
+  String get rawPrefix => 'גולמי: ';
 
   @override
   String get emptyPayload => 'Empty payload';
@@ -199,7 +199,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get noNdefRecordsFound => 'No NDEF records found';
 
   @override
-  String get recordPrefix => 'Record ';
+  String get recordPrefix => 'רשומה ';
 
   @override
   String get recordSuffix => ':';
@@ -220,7 +220,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get contentLabel => 'Content: ';
 
   @override
-  String get rawPayloadLabel => 'Raw Payload: ';
+  String get rawPayloadLabel => 'מטען גולמי: ';
 
   @override
   String get nullPayload => 'null';
@@ -260,7 +260,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get tagIsNotWritableCannotClear => 'Tag is not writable, cannot clear';
 
   @override
-  String get readOperationCompleted => 'Read operation completed';
+  String get readOperationCompleted => 'פעולת הקריאה הושלמה';
 
   @override
   String get writeOperationCompleted => 'Write operation completed';
@@ -275,7 +275,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get theTagIsEmpty => 'The tag is empty';
 
   @override
-  String get record => 'Record ';
+  String get record => 'רשומה ';
 
   @override
   String get type => 'Type: ';
@@ -294,7 +294,7 @@ class AppLocalizationsHe extends AppLocalizations {
       'NDEF records written successfully';
 
   @override
-  String get recordsWritten => 'Records written: ';
+  String get recordsWritten => 'רשומות שנכתבו: ';
 
   @override
   String get writtenRecord => 'Written record ';
@@ -327,7 +327,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get verificationResults => 'Verification Results:';
 
   @override
-  String get recordsFound => 'Records found: ';
+  String get recordsFound => 'רשומות שנמצאו: ';
 
   @override
   String get noNdefRecordsFoundOnTag => 'No NDEF records found on tag';
@@ -384,13 +384,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get scanYourNfcTagDefault => 'Scan your NFC tag';
 
   @override
-  String get readNdefTags => 'Read NDEF Tags';
+  String get readNdefTags => 'קריאת תגי NDEF';
 
   @override
-  String get reading => 'Reading...';
+  String get reading => 'מתבצעת קריאה…';
 
   @override
-  String get readNfcTag => 'Read NFC Tag';
+  String get readNfcTag => 'קריאת תג NFC';
 
   @override
   String get verify => 'Verify';
@@ -408,7 +408,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get nfcStatus => 'NFC Status';
 
   @override
-  String get refreshNfcStatus => 'Refresh NFC Status';
+  String get refreshNfcStatus => 'ריענון מצב NFC';
 
   @override
   String get writeNdefRecords => 'Write NDEF Records';
@@ -457,7 +457,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get writeMultipleRecords => 'Write Multiple Records';
 
   @override
-  String get readOperationFailed => 'Read operation failed';
+  String get readOperationFailed => 'פעולת הקריאה נכשלה';
 
   @override
   String get tagReadSuccessfully => 'Tag read successfully';
@@ -543,7 +543,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get characters => 'Characters';
 
   @override
-  String get scanBarcode => 'Scan Barcode';
+  String get scanBarcode => 'סריקת ברקוד';
 
   @override
   String get barcodeFormat => 'Barcode Format';
@@ -655,7 +655,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get processingImage => 'Processing Image...';
 
   @override
-  String get readyToFlash => 'Ready to Flash';
+  String get readyToFlash => 'מוכן לצריבה';
 
   @override
   String get imageProcessedSuccessfully => 'Image processed successfully.';
@@ -683,7 +683,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get unknownErrorOccurred => 'An unknown error occurred.';
 
   @override
-  String get resultsCleared => 'Results cleared';
+  String get resultsCleared => 'התוצאות התפנו';
 
   @override
   String get clearResults => 'Clear Results';
@@ -734,8 +734,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get noSavedImagesYet => 'No saved images yet';
 
   @override
-  String get saveImagesFromEditor =>
-      'Save images from the editor or import new ones';
+  String get saveImagesFromEditor => 'שמירת תמונות מהעורך או ייבוא חדשות';
 
   @override
   String get enterWifiSSID => 'Enter WiFi SSID';
@@ -808,7 +807,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get deleteAll => 'Delete All';
 
   @override
-  String get renameImage => 'Rename Image';
+  String get renameImage => 'שינוי שם התמונה';
 
   @override
   String get enterNewNameForImage => 'Enter a new name for your image';
@@ -820,7 +819,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get enterImageName => 'Enter image name...';
 
   @override
-  String get rename => 'Rename';
+  String get rename => 'שינוי שם';
 
   @override
   String get imageProperties => 'Image Properties';
@@ -838,17 +837,16 @@ class AppLocalizationsHe extends AppLocalizations {
   String get transferToEpaper => 'Transfer to ePaper';
 
   @override
-  String get saveImage => 'Save Image';
+  String get saveImage => 'שמירת תמונה';
 
   @override
-  String get saveFilteredImageToLibrary =>
-      'Save your filtered image to the library';
+  String get saveFilteredImageToLibrary => 'שמירת התמונה המרוטשת שלך לספרייה';
 
   @override
   String get filterApplied => 'Filter Applied:';
 
   @override
-  String get save => 'Save';
+  String get save => 'שמירה';
 
   @override
   String get noImagesMatchSearch => 'No images match your search';
@@ -857,7 +855,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get vCardDataCannotBeEmpty => 'VCard data cannot be empty';
 
   @override
-  String get renamingImage => 'Renaming image...';
+  String get renamingImage => 'שם התמונה משתנה…';
 
   @override
   String get imageRenamedTo => 'Image renamed to \"';
@@ -902,7 +900,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get failedToTransfer => 'Failed to transfer \"';
 
   @override
-  String get savingImage => 'Saving image...';
+  String get savingImage => 'התמונה נשמרת…';
 
   @override
   String get imageSavedToLibrary => 'Image saved to library!';
@@ -934,7 +932,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get processingImageData => 'Processing image data...';
 
   @override
-  String get refreshingDisplay => 'Refreshing display...';
+  String get refreshingDisplay => 'התצוגה מתרעננת…';
 
   @override
   String get notMagicEpaperHardware => 'Not a Magic ePaper Hardware';
@@ -1004,7 +1002,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get add => 'Add';
 
   @override
-  String get readNfcTags => 'Read NFC Tags';
+  String get readNfcTags => 'קריאת תגי NFC';
 
   @override
   String get writeNfcTags => 'Write NFC Tags';
@@ -1101,10 +1099,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get emptyFieldPlaceholder => 'Not specified';
 
   @override
-  String get productImage => 'Product Image';
+  String get productImage => 'תמונת המוצר';
 
   @override
-  String get productName => 'Product Name';
+  String get productName => 'שם המוצר';
 
   @override
   String get sizeQuantity => 'Size/Quantity';
@@ -1119,7 +1117,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get price => 'Price';
 
   @override
-  String get quantitySize => 'Quantity/Size';
+  String get quantitySize => 'כמות/גודל';
 
   @override
   String get quantitySizeHint =>
@@ -1193,7 +1191,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get pleaseEnterIdNumber => 'Please enter ID number';
 
   @override
-  String get qrCodeData => 'QR Code Data';
+  String get qrCodeData => 'נתוני קוד QR';
 
   @override
   String get enterQrCodeData => 'Enter QR code data';
@@ -1208,7 +1206,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get generateIdCard => 'Generate ID Card';
 
   @override
-  String get profilePhoto => 'Profile Photo';
+  String get profilePhoto => 'תמונת פרופיל';
 
   @override
   String get selected => 'Selected';
@@ -1233,7 +1231,7 @@ class AppLocalizationsHe extends AppLocalizations {
       'Create professional price tags for your products';
 
   @override
-  String get productDetails => 'Product Details';
+  String get productDetails => 'פרטי המוצר';
 
   @override
   String get productNameHint => 'Enter product name (e.g., iPhone 15 Pro)';
@@ -1248,7 +1246,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get currencyHint => '₹';
 
   @override
-  String get required => 'Required';
+  String get required => 'חובה';
 
   @override
   String get priceHint => '999.99';
@@ -1269,10 +1267,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get generatePriceTag => 'Generate Price Tag';
 
   @override
-  String get productImageIn => 'Product Image';
+  String get productImageIn => 'תמונת המוצר';
 
   @override
-  String get productImageSelected => 'Product Image Selected';
+  String get productImageSelected => 'תמונת המוצר נבחרה';
 
   @override
   String get selectProductImage => 'Select Product Image';
@@ -1282,4 +1280,30 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'התמונות עוברות עיבוד…';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -9,11 +9,11 @@ class AppLocalizationsHi extends AppLocalizations {
   AppLocalizationsHi([String locale = 'hi']) : super(locale);
 
   @override
-  String get appName => 'Magic ePaper';
+  String get appName => 'मैजिक ईपेपर';
 
   @override
   String get aboutUsDescription =>
-      'Magic ePaper is an app designed to control and update ePaper displays. The goal is to provide tools for customizing and transferring images, text, and patterns to ePaper screens using NFC. Data transfer from the smartphone to the ePaper hardware is done wirelessly via NFC. The project is built on top of custom firmware and display drivers for seamless communication and efficient image rendering.';
+      'मैजिक ईपेपर एक ऐसा ऐप है जिसे ईपेपर डिस्प्ले को नियंत्रित और अपडेट करने के लिए डिज़ाइन किया गया है। इसका उद्देश्य एनएफसी का उपयोग करके ईपेपर स्क्रीन पर छवियों, टेक्स्ट और पैटर्न को अनुकूलित और स्थानांतरित करने के लिए उपकरण प्रदान करना है। स्मार्टफोन से ईपेपर हार्डवेयर में डेटा ट्रांसफर एनएफसी के माध्यम से वायरलेस तरीके से किया जाता है। यह प्रोजेक्ट निर्बाध संचार और कुशल इमेज रेंडरिंग के लिए कस्टम फ़र्मवेयर और डिस्प्ले ड्राइवरों पर आधारित है।';
 
   @override
   String get developedBy => 'Developed by';
@@ -1282,4 +1282,30 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1309,3 +1309,8 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get textEditorTitle => 'Text Editor';
 }
+
+/// The translations for Norwegian Bokmål, as used in Norway (`nb_NO`).
+class AppLocalizationsNbNo extends AppLocalizationsNb {
+  AppLocalizationsNbNo([String locale = 'nb_NO']) : super(locale);
+}

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1282,9 +1282,30 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
-}
 
-/// The translations for Norwegian Bokmål, as used in Norway (`nb_NO`).
-class AppLocalizationsNbNo extends AppLocalizationsNb {
-  AppLocalizationsNbNo() : super('nb_NO');
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1282,6 +1282,32 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1282,4 +1282,30 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1282,6 +1282,32 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get chooseImageFromGallery => 'Choose image from gallery';
+
+  @override
+  String get processingImages => 'Processing images...';
+
+  @override
+  String get refreshModeInfo => 'Refresh Mode Information';
+
+  @override
+  String get fullRefreshInfo => 'Full Refresh';
+
+  @override
+  String get fullRefreshDescription =>
+      'Completely refreshes the entire display by clearing all pixels and redrawing the image. This provides the best image quality and contrast but takes longer to complete.';
+
+  @override
+  String get partialRefreshInfo => 'Partial Refresh (Waveforms)';
+
+  @override
+  String get partialRefreshDescription =>
+      'Updates only the changed pixels using optimized waveforms. This is faster than full refresh but may result in ghosting or reduced contrast over time.';
+
+  @override
+  String get longPressForInfo => 'Long press for more information';
+
+  @override
+  String get textEditorTitle => 'Text Editor';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/view/text_fit_editor.dart
+++ b/lib/view/text_fit_editor.dart
@@ -4,6 +4,7 @@ import 'package:flutter/rendering.dart';
 import 'dart:ui' as ui;
 import 'package:flutter/services.dart';
 import 'package:magicepaperapp/constants/color_constants.dart';
+import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
 import 'package:magicepaperapp/provider/color_palette_provider.dart';
 
@@ -103,8 +104,8 @@ class TextFitEditorState extends State<TextFitEditor> {
         titleSpacing: 0.0,
         backgroundColor: colorAccent,
         elevation: 0,
-        title: const Text('Text Editor',
-            style: TextStyle(
+        title: Text(AppLocalizations.of(context)!.textEditorTitle,
+            style: const TextStyle(
                 color: Colors.white,
                 fontSize: 13.8,
                 fontWeight: FontWeight.bold)),

--- a/test/text_editor_localization_test.dart
+++ b/test/text_editor_localization_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magicepaperapp/view/text_fit_editor.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:magicepaperapp/l10n/app_localizations.dart';
+import 'package:magicepaperapp/provider/color_palette_provider.dart';
+import 'package:magicepaperapp/provider/getitlocator.dart';
+
+void main() {
+  setUp(() {
+    if (!getIt.isRegistered<ColorPaletteProvider>()) {
+      final provider = ColorPaletteProvider();
+      // Ensure the provider has a default palette so .first doesn't fail
+      provider.colors.addAll([Colors.black, Colors.white, Colors.red]);
+      getIt.registerSingleton<ColorPaletteProvider>(provider);
+    }
+  });
+
+  testWidgets('TextFitEditor AppBar title should be localized', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: [Locale('en')],
+        home: TextFitEditor(width: 400, height: 300),
+      ),
+    );
+
+    // Wait for the UI to settle
+    await tester.pumpAndSettle();
+
+    // Verify that the AppBar title 'Text Editor' is present
+    expect(find.text('Text Editor'), findsOneWidget);
+    
+    // Verify it is inside an AppBar
+    expect(find.byType(AppBar), findsOneWidget);
+  });
+}

--- a/test/text_editor_localization_test.dart
+++ b/test/text_editor_localization_test.dart
@@ -16,6 +16,10 @@ void main() {
     }
   });
 
+  tearDown(() async {
+    await getIt.reset();
+  });
+
   testWidgets('TextFitEditor AppBar title should be localized', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
@@ -33,8 +37,11 @@ void main() {
     // Wait for the UI to settle
     await tester.pumpAndSettle();
 
-    // Verify that the AppBar title 'Text Editor' is present
-    expect(find.text('Text Editor'), findsOneWidget);
+    final BuildContext context = tester.element(find.byType(TextFitEditor));
+    final AppLocalizations localizations = AppLocalizations.of(context)!;
+
+    // Verify that the AppBar title matches the localized value
+    expect(find.text(localizations.textEditorTitle), findsOneWidget);
     
     // Verify it is inside an AppBar
     expect(find.byType(AppBar), findsOneWidget);


### PR DESCRIPTION
**For Issue:**
Fixes #348 

**Description:**

**Context:**
While working on the application, I identified that the TextFitEditor screen was using a hardcoded string ('Text Editor') for its AppBar title. This prevents the screen from being properly localized into other languages supported by the app.

**Changes Made:**

- Localization: Defined the textEditorTitle key in lib/l10n/app_en.arb to manage the UI string centrally.
- Code Refactoring: Updated lib/view/text_fit_editor.dart to fetch the AppBar title dynamically via AppLocalizations.of(context)!.textEditorTitle, removing the hardcoded value.
- Unit/Widget Testing:
     - Created a new test file: test/text_editor_localization_test.dart. 
     - Implemented a widget test to verify that the AppBar title is correctly rendered from the localization system.
     - Configured the test environment to handle GetIt service locator and ColorPaletteProvider dependencies.

**Impact:**
-  i18n Support: The app's header in the Text Editor section is now fully translatable.
- Reliability: The added widget test ensures that future changes won't break the localization or the UI initialization for this screen

**Testing Verification:**
Successfully verified the fix by running: flutter test test/text_editor_localization_test.dart 

**Result:**
All tests passed!


**Evidence:**

<img width="450" height="500" alt="image" src="https://github.com/user-attachments/assets/8aa63d36-0d67-4ae4-8478-a61fbb5a11c5" />
