### PR TITLE
fix: correct flip button callback mismatch in Image Editor

### DIFF
--- a/lib/view/widget/image_list.dart
+++ b/lib/view/widget/image_list.dart
@@ -82,14 +82,14 @@ class ImageList extends StatelessWidget {
           children: [
             _buildFlipButton(
               assetPath: ImageAssets.flipHorizontal,
-              onPressed: onFlipHorizontal,
-              tooltip: 'Flip Horizontally',
+              onPressed: onFlipVertical,
+              tooltip: 'Flip Vertically',
             ),
             const SizedBox(width: 16),
             _buildFlipButton(
               assetPath: ImageAssets.flipHorizontal,
-              onPressed: onFlipVertical,
-              tooltip: 'Flip Vertically',
+              onPressed: onFlipHorizontal,
+              tooltip: 'Flip Horizontally',
               rotation: -1.5708,
             ),
             if (onSave != null) ...[


### PR DESCRIPTION
File: lib/view/widget/image_list.dart

- The two flip buttons both reuse the h-flip.png asset. The unrotated icon visually represents a vertical flip, and the 90°-rotated version visually represents a horizontal flip. However, the onPressed callbacks were wired in reverse — the button that looked like a vertical flip was calling onFlipHorizontal, and vice versa.

- This PR swaps the onPressed callbacks and their tooltips so each button's visible icon correctly matches its behavior.

- _buildFlipButton(onPressed: onFlipHorizontal, tooltip: 'Flip Horizontally'),
- _buildFlipButton(onPressed: onFlipVertical,   tooltip: 'Flip Vertically', rotation: -1.5708),

+ _buildFlipButton(onPressed: onFlipVertical,   tooltip: 'Flip Vertically'),
+ _buildFlipButton(onPressed: onFlipHorizontal, tooltip: 'Flip Horizontally', rotation: -1.5708),


https://github.com/user-attachments/assets/3f6e5ac6-3287-4cdd-bba3-c737409ec011

issue #352

## Summary by Sourcery

Bug Fixes:
- Align the vertical and horizontal flip buttons' callbacks and tooltips with their visual orientation in the image editor toolbar.