### PR TITLE
fix : wrong flip button direction

### DIFF
--- a/lib/view/widget/image_list.dart
+++ b/lib/view/widget/image_list.dart
@@ -84,13 +84,13 @@ class ImageList extends StatelessWidget {
               assetPath: ImageAssets.flipHorizontal,
               onPressed: onFlipHorizontal,
               tooltip: 'Flip Horizontally',
+              rotation: -1.5708,
             ),
             const SizedBox(width: 16),
             _buildFlipButton(
               assetPath: ImageAssets.flipHorizontal,
               onPressed: onFlipVertical,
               tooltip: 'Flip Vertically',
-              rotation: -1.5708,
             ),
             if (onSave != null) ...[
               const SizedBox(width: 16),


### PR DESCRIPTION
Fix issue #352

Just flipped the icon of the good button

## Summary by Sourcery

Bug Fixes:
- Fix the flipped direction on the horizontal image flip button so it matches its action and tooltip.