### PR TITLE
fix: skip permission_handler calls on unsupported desktop platforms

### DIFF
--- a/lib/image_library/services/image_save_handler.dart
+++ b/lib/image_library/services/image_save_handler.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
@@ -61,6 +62,11 @@ class ImageSaveHandler {
   }
 
   Future<bool> requestStoragePermission() async {
+    if (Platform.isLinux || Platform.isMacOS) {
+      _hasStoragePermission = true;
+      return true;
+    }
+
     try {
       var status = await Permission.storage.status;
       if (status.isGranted) {


### PR DESCRIPTION
Fixes #371 

## Changes
- Added a platform guard at the top of requestStoragePermission() in image_save_handler.dart
- On Linux,and macOS, the method now early-returns true and sets _hasStoragePermission = true without invoking permission_handler, since desktop platforms do not require runtime storage permissions

## Summary by Sourcery

Bug Fixes:
- Avoid invoking mobile-only permission handling on Linux and macOS when requesting storage permission for image saving.