### PR TITLE
chore: add issue template as PSLab

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Actual Behaviour.**
+<!--A clear and concise description of the existing behaviour-->
+
+**Expected Behaviour**
+<!--A clear and concise description of what you want to happen.-->
+
+**Steps to reproduce it**
+<!--A clear and concise description of steps you've considered to implement the feature.-->
+
+**Additional context**
+<!--Add any other context or screenshots about the feature request here.-->
+
+**Would you like to work on the issue?**
+<!--Let us know if this issue should be assigned to you or tell us who you think could help to solve this issue.-->

--- a/.github/ISSUE_TEMPLATE/general-issues.md
+++ b/.github/ISSUE_TEMPLATE/general-issues.md
@@ -1,0 +1,16 @@
+---
+name: General Issues
+about: Issues related to docs, workflow, dependency and others
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the issue**
+
+<!--Please state here what you want to do.-->
+
+**Would you like to work on the issue?**
+
+<!--Let us know if this issue should be assigned to you or tell us who you think could help to solve this issue.-->

--- a/.github/ISSUE_TEMPLATE/general-issues.md
+++ b/.github/ISSUE_TEMPLATE/general-issues.md
@@ -1,6 +1,6 @@
 ---
 name: General Issues
-about: Issues related to docs, workflow, dependency and others
+about: Issues related to docs, workflow, dependencies and others
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,6 +1,6 @@
 ---
 name: Report a bug
-about: 'Report a bug which you have noticed, to help us improve Badge-ePaper App '
+about: 'Report a bug which you have noticed, to help us improve Magic-ePaper App '
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,0 +1,39 @@
+---
+name: Report a bug
+about: 'Report a bug which you have noticed, to help us improve Badge-ePaper App '
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+<!--Please state here what is currently happening.-->
+
+**Expected Behavior**
+<!--A clear and concise description of what you want to happen.-->
+
+**Steps to reproduce it**
+<!--Add steps to reproduce the bug.-->
+
+**LogCat for the issue**
+<!--Provide logs for the crash here.-->
+
+**Screenshots of the issue**
+<!--Wherever possible add a screenshot of the issue. Use `<img src="paste-link-here" width=200 />` tag-->
+
+**System Information**
+<table>
+<tr>
+  <td>Platform</td><td>e.g. Android / iOS</td>
+</tr>
+<tr>
+  <td>Device</td><td>e.g. OnePlus 13 / iPhone 15</td>
+</tr>
+<tr>
+  <td>OS Version</td><td>e.g. Android 16 / iOS 18</td>
+</tr>
+</table>
+
+**Would you like to work on the issue?**
+<!--Let us know if this issue should be assigned to you or tell us who you think could help to solve this issue.-->

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,13 @@
+Fixes #<!-- Add issue number here. This will automatically close the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->
+
+## Changes
+<!-- Add here what changes were made in this pull request and if possible provide links. -->
+
+## Screenshots / Recordings
+<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->
+
+**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
+- [ ] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
+- [ ] **No end of file edits**: No modifications done at end of resource files.
+- [ ] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
+- [ ] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

--- a/lib/view/widget/image_list.dart
+++ b/lib/view/widget/image_list.dart
@@ -84,13 +84,13 @@ class ImageList extends StatelessWidget {
               assetPath: ImageAssets.flipHorizontal,
               onPressed: onFlipHorizontal,
               tooltip: 'Flip Horizontally',
+              rotation: -1.5708,
             ),
             const SizedBox(width: 16),
             _buildFlipButton(
               assetPath: ImageAssets.flipHorizontal,
               onPressed: onFlipVertical,
               tooltip: 'Flip Vertically',
-              rotation: -1.5708,
             ),
             if (onSave != null) ...[
               const SizedBox(width: 16),

--- a/lib/view/widget/image_list.dart
+++ b/lib/view/widget/image_list.dart
@@ -84,13 +84,13 @@ class ImageList extends StatelessWidget {
               assetPath: ImageAssets.flipHorizontal,
               onPressed: onFlipHorizontal,
               tooltip: 'Flip Horizontally',
-              rotation: -1.5708,
             ),
             const SizedBox(width: 16),
             _buildFlipButton(
               assetPath: ImageAssets.flipHorizontal,
               onPressed: onFlipVertical,
               tooltip: 'Flip Vertically',
+              rotation: -1.5708,
             ),
             if (onSave != null) ...[
               const SizedBox(width: 16),


### PR DESCRIPTION
Fix #374 

- added same issue template of PSLab
- added pull request template of PSLab

## Summary by Sourcery

Add standardized GitHub issue templates for bugs, feature requests, and general issues to improve issue reporting consistency.

New Features:
- Introduce a bug report issue template tailored for the Badge-ePaper app.
- Introduce a feature request issue template to capture enhancement ideas consistently.
- Introduce a general issues template for documentation, workflow, and other non-bug topics.