### PR TITLE
chore(deps): bump pro_image_editor from 11.15.1 to 12.4.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   image_cropper: ^11.0.0
   app_settings: ^7.0.0
   fluttertoast: ^9.0.0
-  pro_image_editor: ^11.17.0
+  pro_image_editor: ^12.4.4
   gal: ^2.3.1
   file_saver: ^0.3.1
   bot_toast: ^4.1.3


### PR DESCRIPTION
Replace #317

Just updated library, in dependabot branch there is a conflict, so I thought to update to the last version

## Summary by Sourcery

Build:
- Bump pro_image_editor from 11.17.0 to 12.4.4 in pubspec.yaml.