### PR TITLE
Fix:When we change language and we return in prev language nothing works

### DIFF
--- a/lib/view/display_selection_screen.dart
+++ b/lib/view/display_selection_screen.dart
@@ -36,8 +36,8 @@ class _DisplaySelectionScreenState extends State<DisplaySelectionScreen> {
   ];
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<ColorPaletteProvider>(
-      create: (_) => getIt<ColorPaletteProvider>(),
+    return ChangeNotifierProvider<ColorPaletteProvider>.value(
+      value: getIt<ColorPaletteProvider>(),
       builder: (context, child) {
         return CommonScaffold(
           index: 0,


### PR DESCRIPTION
Fixes #356

## Changes
```dart
ChangeNotifierProvider<ColorPaletteProvider>.value(
  value: getIt<ColorPaletteProvider>(),
  child: MyApp(),
)
```
This code doesn't dispose the life cycle of the objects, so we can change multiple times languages and object would be always available

## Screenshots / Recordings
[Screencast From 2026-05-16 18-27-19.webm](https://github.com/user-attachments/assets/436d320f-bbcd-431d-b358-866a88086cd8)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Prevent loss of ColorPaletteProvider state and resulting malfunction when switching languages multiple times.