### PR TITLE
fix: resolved UI transparency bleed in image editor

### DIFF
--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -426,229 +426,236 @@ class _MovableBackgroundImageExampleState
         ),
         child: Scaffold(
             backgroundColor: Colors.black,
-            body: Stack(
-                children: [
-            Positioned.fill(
-            child: LayoutBuilder(builder: (context, constraints) {
-        return CustomPaint(
-        size: Size(constraints.maxWidth, constraints.maxHeight),
-        painter: const PixelTransparentPainter(
-          primary: Colors.white,
-          secondary: Color(0xFFE2E2E2),
-        ),
-        child: FutureBuilder<Uint8List>(
-          future: _loadAndResizeWhiteBoard(),
-          builder: (context, snapshot) {
-            if (!snapshot.hasData) {
-              return const Center(child: CircularProgressIndicator());
-            }
-            return ProImageEditor.memory(
-              snapshot.data!,
-              key: editorKey,
-              callbacks: ProImageEditorCallbacks(
-                onImageEditingComplete: (Uint8List bytes) async {
-                  Navigator.pop(context, bytes);
-                },
-                mainEditorCallbacks: MainEditorCallbacks(
-                  helperLines: const HelperLinesCallbacks(),
-                  onAfterViewInit: () {
-                    editorKey.currentState!.addLayer(
-                      WidgetLayer(
-                        interaction: LayerInteraction(
-                          enableEdit: false,
-                          enableMove: false,
-                          enableRotate: false,
-                          enableScale: false,
-                          enableSelection: false,
-                        ),
-                        offset: Offset.zero,
-                        scale: _initScale,
-                        widget: Image.asset(
-                          ImageAssets.whiteBoard,
-                          width: _canvasWidth,
-                          height: _canvasHeight,
-                          fit: BoxFit.cover,
-                          frameBuilder:
-                              (context, child, frame, wasSynchronouslyLoaded) {
-                            return AnimatedSwitcher(
-                              layoutBuilder: (currentChild, previousChildren) {
-                                return SizedBox(
-                                  width: _canvasWidth,
-                                  height: _canvasHeight,
-                                  child: Stack(
-                                    fit: StackFit.expand,
-                                    alignment: Alignment.center,
-                                    children: <Widget>[
-                                      ...previousChildren,
-                                      if (currentChild != null) currentChild,
-                                    ],
-                                  ),
-                                );
-                              },
-                              duration: const Duration(milliseconds: 1),
-                              child: frame != null
-                                  ? child
-                                  : const Center(
-                                      child: CircularProgressIndicator(),
-                                    ),
-                            );
+            body: Stack(children: [
+              Positioned.fill(
+                  child: LayoutBuilder(builder: (context, constraints) {
+                return CustomPaint(
+                  size: Size(constraints.maxWidth, constraints.maxHeight),
+                  painter: const PixelTransparentPainter(
+                    primary: Colors.white,
+                    secondary: Color(0xFFE2E2E2),
+                  ),
+                  child: FutureBuilder<Uint8List>(
+                    future: _loadAndResizeWhiteBoard(),
+                    builder: (context, snapshot) {
+                      if (!snapshot.hasData) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+                      return ProImageEditor.memory(
+                        snapshot.data!,
+                        key: editorKey,
+                        callbacks: ProImageEditorCallbacks(
+                          onImageEditingComplete: (Uint8List bytes) async {
+                            Navigator.pop(context, bytes);
                           },
-                        ),
-                      ),
-                    );
-
-                    // Add initial layers from widget parameter
-                    if (widget.initialLayers != null) {
-                      addInitialLayers(widget.initialLayers!);
-                    }
-                  },
-                ),
-              ),
-              configs: ProImageEditorConfigs(
-                designMode: platformDesignMode,
-                imageGeneration: ImageGenerationConfigs(
-                  cropToDrawingBounds: true,
-                  allowEmptyEditingCompletion: false,
-                  outputFormat: OutputFormat.png,
-
-                  /// Set the pixel ratio manually. You can also set this
-                  /// value higher than the device pixel ratio for higher
-                  /// quality.
-                  customPixelRatio: max(2000 / MediaQuery.sizeOf(context).width,
-                      MediaQuery.devicePixelRatioOf(context)),
-                ),
-                mainEditor: MainEditorConfigs(
-                  enableZoom: true,
-                  enableCloseButton: !isDesktopMode(context),
-                  tools: const [
-                    SubEditorMode.paint,
-                    SubEditorMode.text,
-                    SubEditorMode.emoji,
-                  ],
-                  widgets: MainEditorWidgets(
-                    bodyItems: (editor, rebuildStream) {
-                      return [
-                        ReactiveWidget(
-                          stream: rebuildStream,
-                          builder: (_) => editor.isSubEditorOpen
-                              ? const SizedBox.shrink()
-                              : Positioned(
-                                  bottom: 20,
-                                  left: 0,
-                                  child: Container(
-                                    decoration: BoxDecoration(
-                                      color: Colors.lightBlue.shade200,
-                                      borderRadius: const BorderRadius.only(
-                                        topRight: Radius.circular(100),
-                                        bottomRight: Radius.circular(100),
-                                      ),
-                                    ),
-                                    child: IconButton(
-                                      onPressed: () =>
-                                          _openReorderSheet(editor),
-                                      icon: const Icon(
-                                        Icons.reorder,
-                                        color: Colors.white,
-                                      ),
-                                    ),
+                          mainEditorCallbacks: MainEditorCallbacks(
+                            helperLines: const HelperLinesCallbacks(),
+                            onAfterViewInit: () {
+                              editorKey.currentState!.addLayer(
+                                WidgetLayer(
+                                  interaction: LayerInteraction(
+                                    enableEdit: false,
+                                    enableMove: false,
+                                    enableRotate: false,
+                                    enableScale: false,
+                                    enableSelection: false,
+                                  ),
+                                  offset: Offset.zero,
+                                  scale: _initScale,
+                                  widget: Image.asset(
+                                    ImageAssets.whiteBoard,
+                                    width: _canvasWidth,
+                                    height: _canvasHeight,
+                                    fit: BoxFit.cover,
+                                    frameBuilder: (context, child, frame,
+                                        wasSynchronouslyLoaded) {
+                                      return AnimatedSwitcher(
+                                        layoutBuilder:
+                                            (currentChild, previousChildren) {
+                                          return SizedBox(
+                                            width: _canvasWidth,
+                                            height: _canvasHeight,
+                                            child: Stack(
+                                              fit: StackFit.expand,
+                                              alignment: Alignment.center,
+                                              children: <Widget>[
+                                                ...previousChildren,
+                                                if (currentChild != null)
+                                                  currentChild,
+                                              ],
+                                            ),
+                                          );
+                                        },
+                                        duration:
+                                            const Duration(milliseconds: 1),
+                                        child: frame != null
+                                            ? child
+                                            : const Center(
+                                                child:
+                                                    CircularProgressIndicator(),
+                                              ),
+                                      );
+                                    },
                                   ),
                                 ),
+                              );
+
+                              // Add initial layers from widget parameter
+                              if (widget.initialLayers != null) {
+                                addInitialLayers(widget.initialLayers!);
+                              }
+                            },
+                          ),
                         ),
-                      ];
+                        configs: ProImageEditorConfigs(
+                          designMode: platformDesignMode,
+                          imageGeneration: ImageGenerationConfigs(
+                            cropToDrawingBounds: true,
+                            allowEmptyEditingCompletion: false,
+                            outputFormat: OutputFormat.png,
+
+                            /// Set the pixel ratio manually. You can also set this
+                            /// value higher than the device pixel ratio for higher
+                            /// quality.
+                            customPixelRatio: max(
+                                2000 / MediaQuery.sizeOf(context).width,
+                                MediaQuery.devicePixelRatioOf(context)),
+                          ),
+                          mainEditor: MainEditorConfigs(
+                            enableZoom: true,
+                            enableCloseButton: !isDesktopMode(context),
+                            tools: const [
+                              SubEditorMode.paint,
+                              SubEditorMode.text,
+                              SubEditorMode.emoji,
+                            ],
+                            widgets: MainEditorWidgets(
+                              bodyItems: (editor, rebuildStream) {
+                                return [
+                                  ReactiveWidget(
+                                    stream: rebuildStream,
+                                    builder: (_) => editor.isSubEditorOpen
+                                        ? const SizedBox.shrink()
+                                        : Positioned(
+                                            bottom: 20,
+                                            left: 0,
+                                            child: Container(
+                                              decoration: BoxDecoration(
+                                                color:
+                                                    Colors.lightBlue.shade200,
+                                                borderRadius:
+                                                    const BorderRadius.only(
+                                                  topRight:
+                                                      Radius.circular(100),
+                                                  bottomRight:
+                                                      Radius.circular(100),
+                                                ),
+                                              ),
+                                              child: IconButton(
+                                                onPressed: () =>
+                                                    _openReorderSheet(editor),
+                                                icon: const Icon(
+                                                  Icons.reorder,
+                                                  color: Colors.white,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                  ),
+                                ];
+                              },
+                              bottomBar: (editor, rebuildStream, key) =>
+                                  ReactiveWidget(
+                                stream: rebuildStream,
+                                key: key,
+                                builder: (_) => _bottomNavigationBar(
+                                  editor,
+                                  constraints,
+                                ),
+                              ),
+                            ),
+                            style: const MainEditorStyle(
+                              uiOverlayStyle: SystemUiOverlayStyle(
+                                statusBarColor: Colors.black,
+                              ),
+                              background: ui.Color.fromARGB(255, 155, 152, 152),
+                            ),
+                          ),
+                          paintEditor: PaintEditorConfigs(
+                            enableZoom: true,
+                            widgets: PaintEditorWidgets(
+                              colorPicker: (editor, rebuildStream, currentColor,
+                                      setColor) =>
+                                  null,
+                              bodyItems: _buildPaintEditorBody,
+                            ),
+                            style: const PaintEditorStyle(
+                              initialColor: Colors.black,
+                              uiOverlayStyle: SystemUiOverlayStyle(
+                                statusBarColor: Colors.black,
+                              ),
+                              background: Colors.black,
+                            ),
+                          ),
+                          textEditor: TextEditorConfigs(
+                            customTextStyles: [
+                              GoogleFonts.roboto(),
+                              GoogleFonts.averiaLibre(),
+                              GoogleFonts.lato(),
+                              GoogleFonts.comicNeue(),
+                              GoogleFonts.actor(),
+                              GoogleFonts.odorMeanChey(),
+                              GoogleFonts.nabla(),
+                            ],
+                            widgets: TextEditorWidgets(
+                              appBar: (textEditor, rebuildStream) => null,
+                              colorPicker: (editor, rebuildStream, currentColor,
+                                      setColor) =>
+                                  null,
+                              bottomBar: (textEditor, rebuildStream) => null,
+                              bodyItems: _buildTextEditorBody,
+                            ),
+                            style: TextEditorStyle(
+                                textFieldMargin: EdgeInsets.zero,
+                                bottomBarBackground: Colors.black,
+                                bottomBarMainAxisAlignment: !_useMaterialDesign
+                                    ? MainAxisAlignment.spaceEvenly
+                                    : MainAxisAlignment.start),
+                          ),
+                          cropRotateEditor: const CropRotateEditorConfigs(),
+                          filterEditor: const FilterEditorConfigs(),
+                          blurEditor: const BlurEditorConfigs(),
+                          stickerEditor: StickerEditorConfigs(
+                            initWidth: (_editorSize.aspectRatio >
+                                        (widget.width / widget.height)
+                                    ? _editorSize.height
+                                    : _editorSize.width) /
+                                _initScale,
+                            builder: (setLayer, scrollController) {
+                              return const SizedBox();
+                            },
+                          ),
+                        ),
+                      );
                     },
-                    bottomBar: (editor, rebuildStream, key) => ReactiveWidget(
-                      stream: rebuildStream,
-                      key: key,
-                      builder: (_) => _bottomNavigationBar(
-                        editor,
-                        constraints,
-                      ),
-                    ),
                   ),
-                  style: const MainEditorStyle(
-                    uiOverlayStyle: SystemUiOverlayStyle(
-                      statusBarColor: Colors.black,
-                    ),
-                    background: ui.Color.fromARGB(255, 155, 152, 152),
-                  ),
-                ),
-                paintEditor: PaintEditorConfigs(
-                  enableZoom: true,
-                  widgets: PaintEditorWidgets(
-                    colorPicker:
-                        (editor, rebuildStream, currentColor, setColor) => null,
-                    bodyItems: _buildPaintEditorBody,
-                  ),
-                  style: const PaintEditorStyle(
-                    initialColor: Colors.black,
-                    uiOverlayStyle: SystemUiOverlayStyle(
-                      statusBarColor: Colors.black,
-                    ),
-                    background: Colors.black,
-                  ),
-                ),
-                textEditor: TextEditorConfigs(
-                  customTextStyles: [
-                    GoogleFonts.roboto(),
-                    GoogleFonts.averiaLibre(),
-                    GoogleFonts.lato(),
-                    GoogleFonts.comicNeue(),
-                    GoogleFonts.actor(),
-                    GoogleFonts.odorMeanChey(),
-                    GoogleFonts.nabla(),
-                  ],
-                  widgets: TextEditorWidgets(
-                    appBar: (textEditor, rebuildStream) => null,
-                    colorPicker:
-                        (editor, rebuildStream, currentColor, setColor) => null,
-                    bottomBar: (textEditor, rebuildStream) => null,
-                    bodyItems: _buildTextEditorBody,
-                  ),
-                  style: TextEditorStyle(
-                      textFieldMargin: EdgeInsets.zero,
-                      bottomBarBackground: Colors.black,
-                      bottomBarMainAxisAlignment: !_useMaterialDesign
-                          ? MainAxisAlignment.spaceEvenly
-                          : MainAxisAlignment.start),
-                ),
-                cropRotateEditor: const CropRotateEditorConfigs(),
-                filterEditor: const FilterEditorConfigs(),
-                blurEditor: const BlurEditorConfigs(),
-                stickerEditor: StickerEditorConfigs(
-                  initWidth:
-                      (_editorSize.aspectRatio > (widget.width / widget.height)
-                              ? _editorSize.height
-                              : _editorSize.width) /
-                          _initScale,
-                  builder: (setLayer, scrollController) {
-                    return const SizedBox();
-                  },
-                ),
+                );
+              })),
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                height: MediaQuery.viewPaddingOf(context).top,
+                child: Container(color: Colors.black),
               ),
-            );
-          },
-        ),
-        );
-        }
-        )
-        ),
-                  Positioned(
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    height: MediaQuery.viewPaddingOf(context).top,
-                    child: Container(color: Colors.black), ),
-                  Positioned(
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
-                    height: MediaQuery.viewPaddingOf(context).bottom,
-                    child: Container(color: Colors.black),
-                  ),
-        ]
-        )
-        )
-    );
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: MediaQuery.viewPaddingOf(context).bottom,
+                child: Container(color: Colors.black),
+              ),
+            ])));
   }
 
   Widget _bottomNavigationBar(

--- a/lib/pro_image_editor/features/movable_background_image.dart
+++ b/lib/pro_image_editor/features/movable_background_image.dart
@@ -417,8 +417,20 @@ class _MovableBackgroundImageExampleState
   @override
   Widget build(BuildContext context) {
     _calculateCanvasDimensions(MediaQuery.sizeOf(context));
-    return LayoutBuilder(builder: (context, constraints) {
-      return CustomPaint(
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+        value: const SystemUiOverlayStyle(
+          statusBarColor: Colors.black,
+          systemNavigationBarColor: Colors.black,
+          statusBarIconBrightness: Brightness.light,
+          systemNavigationBarIconBrightness: Brightness.light,
+        ),
+        child: Scaffold(
+            backgroundColor: Colors.black,
+            body: Stack(
+                children: [
+            Positioned.fill(
+            child: LayoutBuilder(builder: (context, constraints) {
+        return CustomPaint(
         size: Size(constraints.maxWidth, constraints.maxHeight),
         painter: const PixelTransparentPainter(
           primary: Colors.white,
@@ -616,8 +628,27 @@ class _MovableBackgroundImageExampleState
             );
           },
         ),
-      );
-    });
+        );
+        }
+        )
+        ),
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: MediaQuery.viewPaddingOf(context).top,
+                    child: Container(color: Colors.black), ),
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    height: MediaQuery.viewPaddingOf(context).bottom,
+                    child: Container(color: Colors.black),
+                  ),
+        ]
+        )
+        )
+    );
   }
 
   Widget _bottomNavigationBar(


### PR DESCRIPTION
Fixes #350 
Override #351

## Changes
Wrapped CustomPaint in AnnotatedRegion<SystemUiOverlayStyle> and Positioned manually topbar and bottombar

> Important
> See [this commit](https://github.com/fossasia/magic-epaper-app/pull/418/changes/3584af4de321b4b7a1de7c270ee4a64d3801e649) to see real differences

## Screenshots / Recordings
<img width="390" height="782" alt="image" src="https://github.com/user-attachments/assets/cece1e0b-3398-4bb8-8e64-3f73a9154723" />

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Prevent the image editor canvas from bleeding under transparent system UI by enforcing black status and navigation bar backgrounds and appropriate overlay styles.