### PR TITLE
fix: NFC stops working after scanning incompatible tag

### DIFF
--- a/lib/ndef_screen/controller/nfc_controller.dart
+++ b/lib/ndef_screen/controller/nfc_controller.dart
@@ -138,9 +138,11 @@ class NFCController extends ChangeNotifier {
 
   Future<void> verifyWrite() async {
     if (_availability != NFCAvailability.available) return;
+    _setReading(true);
     _setResult(appLocalizations.scanningTagForVerification);
     final result = await NFCOperationsService.verifyTag();
     _setResult(result.message);
+    _setReading(false);
   }
 
   Future<void> writeVCardRecord(VCardData vCardData) async {

--- a/lib/ndef_screen/widgets/nfc_read_card.dart
+++ b/lib/ndef_screen/widgets/nfc_read_card.dart
@@ -94,7 +94,7 @@ class NFCReadCard extends StatelessWidget {
                       ),
                       const SizedBox(width: 12),
                       _buildActionButton(
-                        onPressed: onVerify,
+                        onPressed: isReading ? null : onVerify,
                         icon: const Icon(Icons.search, color: colorWhite),
                         label: appLocalizations.verify,
                         backgroundColor: Colors.orange,


### PR DESCRIPTION
Fixes #422

## Changes
- Added `_isReading` state management to `verifyWrite()` in `NFCController`, matching the pattern used by `readNDEF()` and other operations. Previously the Verify operation had no state flag, allowing concurrent NFC sessions.
- Added `isReading` guard to the Verify button in `NFCReadCard` so it is disabled during any NFC operation, preventing the user from tapping Verify multiple times.

## Screenshots / Recordings
> N/A - The fix is a non-UI logic change.

**Checklist**:
- [ ] **No hard coding**: Used existing `appLocalizations` strings and state management patterns.
- [ ] **No end of file edits**: No modifications at end of resource files.
- [ ] **Code reformatting**: Unable to run `dart format` in this environment.
- [ ] **Code analysis**: Unable to run `flutter analyze` in this environment.
