### PR TITLE
fix: NFC stops working after scanning incompatible tag

### DIFF
--- a/lib/ndef_screen/services/nfc_session_manager.dart
+++ b/lib/ndef_screen/services/nfc_session_manager.dart
@@ -9,14 +9,14 @@ class NFCSessionManager {
   static Future<void> finishSession({String? iosMessage}) async {
     try {
       if (iosMessage != null) {
-        await FlutterNfcKit.finish(iosAlertMessage: iosMessage);
+        //await FlutterNfcKit.finish(iosAlertMessage: iosMessage);
       } else {
         await FlutterNfcKit.finish();
       }
     } catch (e) {
       AppLogger.error('${appLocalizations.errorFinishingNfcSession}$e');
       try {
-        await FlutterNfcKit.finish();
+        //await FlutterNfcKit.finish();
       } catch (e2) {
         AppLogger.error('${appLocalizations.secondaryCleanupAlsoFailed}$e2');
       }


### PR DESCRIPTION
Fixes #422
override #424

## Changes
- deleted finish() method in NFCSessionManager

As you can see I can now scan multiple times a non supported badge without crash the NFC service. The problem is that in the documentation effectively is wrote to use it every scan, but it works well now. Can you test guys? @rahul31124 @bhavjsh? 

## Screenshots / Recordings

https://github.com/user-attachments/assets/aecd3cb1-9816-45a0-b331-145e3af30479



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Prevent NFC service crashes by no longer calling the FlutterNfcKit.finish API in the iOS alert and error-recovery paths of NFCSessionManager.