### PR TITLE
fix: dispose TextEditingController in TextFitEditor to prevent memory leak

### DIFF
--- a/lib/view/text_fit_editor.dart
+++ b/lib/view/text_fit_editor.dart
@@ -37,6 +37,12 @@ class TextFitEditorState extends State<TextFitEditor> {
     );
   }
 
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
   Size _calculateCanvas(Size screenSize) {
     final double targetAspect = widget.width / widget.height;
     final double availableWidth = screenSize.width - 32;


### PR DESCRIPTION
## Problem
`TextFitEditorState` creates a `TextEditingController` 
in a field declaration but never disposes it in a 
`dispose()` method. This causes a memory leak every 
time the Text Editor screen is opened, similar to the 
issue previously fixed in `ImageRenameDialog` (PR #415).

## Fix
Added a `dispose()` override that properly disposes 
`_controller` and calls `super.dispose()`.

## Files Changed
- lib/view/text_fit_editor.dart
  - Added dispose() method

## Checklist
- [x] No hard coding
- [x] No end of file edits
- [x] Code reformatting: formatted using `dart format`
- [x] Code analysis: passes `flutter analyze`

## Summary by Sourcery

Bug Fixes:
- Fix a memory leak in TextFitEditor by disposing the TextEditingController in the widget's dispose lifecycle.