### PR TITLE
fix: add mounted check before setState in WaveshareTransferDialog to prevent crash

### DIFF
--- a/lib/view/widget/waveshare_transfer_dialog.dart
+++ b/lib/view/widget/waveshare_transfer_dialog.dart
@@ -76,6 +76,8 @@ class _WaveshareTransferDialogState extends State<WaveshareTransferDialog>
     });
     await Future.delayed(const Duration(milliseconds: 200));
 
+    if (!mounted) return;
+
     _processedImage = img.Image.from(widget.image);
 
     setState(() {


### PR DESCRIPTION
## Problem
In `_processAndInitiateFlash()`, `setState()` is called  right after `await Future.delayed(...)` without checking if the widget is still `mounted`. If the user dismisses  this dialog during that delay, `setState()` gets called  on a disposed widget, causing a crash:
"setState() called after dispose()".

## Fix
Added `if (!mounted) return;` check right after the  `Future.delayed` call, before accessing `widget.image`  and calling `setState()`.

## Files Changed
- lib/view/widget/waveshare_transfer_dialog.dart

## Checklist
- [x] No hard coding
- [x] No end of file edits
- [x] Code reformatting: formatted using `dart format`
- [x] Code analysis: passes `flutter analyze`

## Summary by Sourcery

Bug Fixes:
- Add a mounted check after the delay in the Waveshare transfer dialog to avoid setState being called on a disposed widget.