### PR TITLE
fix: add mounted checks before setState/handleWriteResult calls in NFCWriteScreen to prevent crash

### DIFF
--- a/lib/ndef_screen/nfc_write_screen.dart
+++ b/lib/ndef_screen/nfc_write_screen.dart
@@ -165,6 +165,7 @@ class _NFCWriteScreenState extends State<NFCWriteScreen>
   Future<void> _writeAppLauncher() async {
     if (_selectedApp != null) {
       await _nfcController.writeAppLauncherRecord(_selectedApp!.packageName);
+      if (!mounted) return;
       _handleWriteResult();
       if (_nfcController.result.contains(appLocalizations.successfully)) {
         setState(() {
@@ -249,10 +250,12 @@ class _NFCWriteScreenState extends State<NFCWriteScreen>
                       setState(() => _vCardData = vCardData),
                   onWriteText: () async {
                     await _nfcController.writeTextRecord(_textValue);
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                   onWriteUrl: () async {
                     await _nfcController.writeUrlRecord(_urlValue);
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                   onWriteWifi: () async {
@@ -260,11 +263,13 @@ class _NFCWriteScreenState extends State<NFCWriteScreen>
                       _wifiSSIDValue,
                       _wifiPasswordValue,
                     );
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                   onWriteVCard: () async {
                     if (_vCardData != null) {
                       await _nfcController.writeVCardRecord(_vCardData!);
+                      if (!mounted) return;
                       _handleWriteResult();
                     }
                   },
@@ -276,6 +281,7 @@ class _NFCWriteScreenState extends State<NFCWriteScreen>
                       _wifiPasswordValue,
                       _vCardData,
                     );
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                 ),


### PR DESCRIPTION
## Problem
Several write callbacks in `NFCWriteScreen` (writeText,  writeUrl, writeWifi, writeVCard, writeMultiple, and  writeAppLauncher) call `await` on NFC controller methods  followed by `_handleWriteResult()` and/or `setState()`  without checking if the widget is still `mounted`.

If the user navigates away from this screen while an NFC  write operation is in progress, this causes a crash: "setState() called after dispose()".

## Fix
Added `if (!mounted) return;` checks immediately after  each `await` call and before `_handleWriteResult()` or  `setState()` is invoked, consistent with the pattern  already used elsewhere in this file (e.g. `_showSnackBar`).

## Files Changed
- lib/ndef_screen/nfc_write_screen.dart

## Checklist
- [x] No hard coding
- [x] No end of file edits
- [x] Code reformatting: formatted using `dart format`
- [x] Code analysis: passes `flutter analyze`