### PR TITLE
fix: add mounted checks before setState/handleWriteResult calls in NDEFScreen to prevent crash

### DIFF
--- a/lib/ndef_screen/ndef_screen.dart
+++ b/lib/ndef_screen/ndef_screen.dart
@@ -165,6 +165,7 @@ class _NDEFScreenState extends State<NDEFScreen> with WidgetsBindingObserver {
   Future<void> _writeAppLauncher() async {
     if (_selectedApp != null) {
       await _nfcController.writeAppLauncherRecord(_selectedApp!.packageName);
+      if (!mounted) return;
       _handleWriteResult();
       if (_nfcController.result.contains(appLocalizations.successfully)) {
         setState(() {
@@ -265,20 +266,24 @@ class _NDEFScreenState extends State<NDEFScreen> with WidgetsBindingObserver {
                       setState(() => _vCardData = vCardData),
                   onWriteText: () async {
                     await _nfcController.writeTextRecord(_textValue);
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                   onWriteUrl: () async {
                     await _nfcController.writeUrlRecord(_urlValue);
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                   onWriteWifi: () async {
                     await _nfcController.writeWifiRecord(
                         _wifiSSIDValue, _wifiPasswordValue);
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                   onWriteVCard: () async {
                     if (_vCardData != null) {
                       await _nfcController.writeVCardRecord(_vCardData!);
+                      if (!mounted) return;
                       _handleWriteResult();
                     }
                   },
@@ -290,6 +295,7 @@ class _NDEFScreenState extends State<NDEFScreen> with WidgetsBindingObserver {
                       _wifiPasswordValue,
                       _vCardData,
                     );
+                    if (!mounted) return;
                     _handleWriteResult();
                   },
                 ),


### PR DESCRIPTION
## Problem
Several write callbacks in `NDEFScreen` (writeText,  writeUrl, writeWifi, writeVCard, writeMultiple, and  writeAppLauncher) call `await` on NFC controller methods  followed by `_handleWriteResult()` and/or `setState()`  without checking if the widget is still `mounted`.

If the user navigates away from this screen while an NFC  write operation is in progress, this causes a crash: "setState() called after dispose()".

## Fix
Added `if (!mounted) return;` checks immediately after  each `await` call and before `_handleWriteResult()` or  `setState()` is invoked, consistent with the pattern  already used elsewhere in this file (e.g. `_showSnackBar`  and `_onNFCStateChanged`).

## Files Changed
- lib/ndef_screen/ndef_screen.dart

## Checklist
- [x] No hard coding
- [x] No end of file edits
- [x] Code reformatting: formatted using `dart format`
- [x] Code analysis: passes `flutter analyze`

## Summary by Sourcery

Bug Fixes:
- Prevent crashes caused by calling setState or write result handlers after navigating away from NDEFScreen during an NFC write operation.