### PR TITLE
fix: add mounted check before setState in ConfigurableEpdDialog to prevent crash

### DIFF
--- a/lib/view/widget/configurable_epd_dialog.dart
+++ b/lib/view/widget/configurable_epd_dialog.dart
@@ -308,6 +308,7 @@ class _ConfigurableEpdDialogState extends State<ConfigurableEpdDialog> {
             ));
 
     if (pickedColor != null) {
+      if (!mounted) return;
       setState(() {
         _currentColors.add(pickedColor);
       });


### PR DESCRIPTION
## Problem
In `_addColor()` method of `ConfigurableEpdDialog`,  `setState()` is called after `await showDialog<Color>()`  without checking if the widget is still `mounted`. 

If the parent dialog is dismissed while the color  picker dialog is still open, `setState()` gets called 
on a disposed widget, causing a crash: "setState() called after dispose()".

## Fix
Added `if (!mounted) return;` check after  `await showDialog<Color>()` and before `setState()`.

## Files Changed
- lib/view/widget/configurable_epd_dialog.dart

## Checklist
- [x] No hard coding
- [x] No end of file edits
- [x] Code reformatting: formatted using `dart format`
- [x] Code analysis: passes `flutter analyze`

Fixes #464