### PR TITLE
fix: make card template grid responsive on large screens

### DIFF
--- a/lib/card_templates/card_template_selection_view.dart
+++ b/lib/card_templates/card_template_selection_view.dart
@@ -54,11 +54,11 @@ class CardTemplateSelectionView extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.fromLTRB(16.0, 24, 16.0, 16.0),
           child: GridView.builder(
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 2,
-              childAspectRatio: 0.6,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 240,
+              childAspectRatio: 0.7,
+              mainAxisSpacing: 16,
+              crossAxisSpacing: 16,
             ),
             itemCount: _getTemplates().length,
             itemBuilder: (context, index) {


### PR DESCRIPTION
Fixes #476

## Changes
Made the card template grid responsive.
Replaced the fixed 2-column grid with ```SliverGridDelegateWithMaxCrossAxisExtent```

## Screenshots / Recordings

https://github.com/user-attachments/assets/0bf99895-6536-4328-91be-a8f168d63e63



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Resolve layout issues where the card template grid appeared cramped or suboptimal on wide displays.