### PR TITLE
fix: Prevent transfer on unsupported NFC

### DIFF
--- a/lib/util/epd/epd.dart
+++ b/lib/util/epd/epd.dart
@@ -17,15 +17,19 @@ abstract class Epd extends DisplayDevice {
   Future<void> transfer(BuildContext context, img.Image image,
       {Waveform? waveform}) async {
     if (!context.mounted) return;
+    final protocol = Protocol(epd: this);
 
+    if (!await protocol.ensureNfcAvailable()) {
+      return;
+    }
+    if (!context.mounted) return;
     final rotatedImage = img.copyRotate(image, angle: 90);
     await TransferProgressDialog.show(
       context: context,
       finalImg: rotatedImage,
       transferFunction: (img, onProgress, onTagDetected) async {
         if (!context.mounted) return;
-        final currentEpdDevice = this;
-        return await Protocol(epd: currentEpdDevice).writeImages(
+        return await protocol.writeImages(
           img,
           onProgress: onProgress,
           onTagDetected: onTagDetected,

--- a/lib/util/epd/epd.dart
+++ b/lib/util/epd/epd.dart
@@ -17,19 +17,15 @@ abstract class Epd extends DisplayDevice {
   Future<void> transfer(BuildContext context, img.Image image,
       {Waveform? waveform}) async {
     if (!context.mounted) return;
-    final protocol = Protocol(epd: this);
 
-    if (!await protocol.ensureNfcAvailable()) {
-      return;
-    }
-    if (!context.mounted) return;
     final rotatedImage = img.copyRotate(image, angle: 90);
     await TransferProgressDialog.show(
       context: context,
       finalImg: rotatedImage,
       transferFunction: (img, onProgress, onTagDetected) async {
         if (!context.mounted) return;
-        return await protocol.writeImages(
+        final currentEpdDevice = this;
+        return await Protocol(epd: currentEpdDevice).writeImages(
           img,
           onProgress: onProgress,
           onTagDetected: onTagDetected,

--- a/lib/util/protocol.dart
+++ b/lib/util/protocol.dart
@@ -12,6 +12,7 @@ import 'package:magicepaperapp/util/magic_epaper_firmware.dart';
 import 'package:magicepaperapp/util/nfc_settings_launcher.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
+import 'package:magicepaperapp/ndef_screen/services/nfc_availability_service.dart';
 import 'app_logger.dart';
 
 AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
@@ -110,7 +111,7 @@ class Protocol {
   }
 
   Future<bool> ensureNfcAvailable() async {
-    final availability = await FlutterNfcKit.nfcAvailability;
+    final availability = await NFCAvailabilityService.checkAvailability();
 
     switch (availability) {
       case NFCAvailability.available:

--- a/lib/util/protocol.dart
+++ b/lib/util/protocol.dart
@@ -109,31 +109,41 @@ class Protocol {
     return chunks;
   }
 
+  Future<bool> ensureNfcAvailable() async {
+    final availability = await FlutterNfcKit.nfcAvailability;
+
+    switch (availability) {
+      case NFCAvailability.available:
+        return true;
+
+      case NFCAvailability.disabled:
+        Fluttertoast.showToast(
+          msg: appLocalizations.nfcIsDisabledPleaseEnableIt,
+        );
+
+        if (Platform.isAndroid) {
+          await NFCSettingsLauncher.openNFCSettings();
+        } else if (Platform.isIOS) {
+          await AppSettings.openAppSettings();
+        }
+
+        return false;
+
+      case NFCAvailability.not_supported:
+        Fluttertoast.showToast(
+          msg: appLocalizations.thisDeviceDoesNotSupportNfc,
+        );
+        return false;
+    }
+  }
+
   Future<void> writeImages(
     img.Image image, {
     ProgressCallback? onProgress,
     TagDetectedCallback? onTagDetected,
     Waveform? waveform,
   }) async {
-    var availability = await FlutterNfcKit.nfcAvailability;
-    switch (availability) {
-      case NFCAvailability.available:
-        break;
-      case NFCAvailability.disabled:
-        Fluttertoast.showToast(
-            msg: appLocalizations.nfcIsDisabledPleaseEnableIt);
-        if (Platform.isAndroid) {
-          await NFCSettingsLauncher.openNFCSettings();
-        } else if (Platform.isIOS) {
-          await AppSettings.openAppSettings();
-        }
-        return;
-      case NFCAvailability.not_supported:
-        Fluttertoast.showToast(
-            msg: appLocalizations.thisDeviceDoesNotSupportNfc);
-        return;
-    }
-
+    if (!await ensureNfcAvailable()) return;
     onProgress?.call(0.0, appLocalizations.waitingForNfcTag);
     Fluttertoast.showToast(
         msg: appLocalizations.bringPhoneNearMagicEpaperHardware);

--- a/lib/util/protocol.dart
+++ b/lib/util/protocol.dart
@@ -110,31 +110,23 @@ class Protocol {
     return chunks;
   }
 
-  Future<bool> ensureNfcAvailable() async {
+  Future<void> ensureNfcAvailable() async {
     final availability = await NFCAvailabilityService.checkAvailability();
 
     switch (availability) {
       case NFCAvailability.available:
-        return true;
+        return;
 
       case NFCAvailability.disabled:
-        Fluttertoast.showToast(
-          msg: appLocalizations.nfcIsDisabledPleaseEnableIt,
-        );
-
         if (Platform.isAndroid) {
           await NFCSettingsLauncher.openNFCSettings();
         } else if (Platform.isIOS) {
           await AppSettings.openAppSettings();
         }
-
-        return false;
+        throw appLocalizations.nfcIsDisabledPleaseEnableIt;
 
       case NFCAvailability.not_supported:
-        Fluttertoast.showToast(
-          msg: appLocalizations.thisDeviceDoesNotSupportNfc,
-        );
-        return false;
+        throw appLocalizations.thisDeviceDoesNotSupportNfc;
     }
   }
 
@@ -144,7 +136,7 @@ class Protocol {
     TagDetectedCallback? onTagDetected,
     Waveform? waveform,
   }) async {
-    if (!await ensureNfcAvailable()) return;
+    await ensureNfcAvailable();
     onProgress?.call(0.0, appLocalizations.waitingForNfcTag);
     Fluttertoast.showToast(
         msg: appLocalizations.bringPhoneNearMagicEpaperHardware);


### PR DESCRIPTION
Fixes #485

## Changes

- Added an NFC availability check before starting the transfer process.
- Prevented the transfer flow from starting on devices without NFC support.
- Reused the same `Protocol` instance for NFC validation and image transfer.

## Screenshots / Recordings
devices without NFC:

https://github.com/user-attachments/assets/4ef29cda-957b-42fa-ba34-3103e01ad0c3


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Prevent starting NFC image transfer on devices where NFC is unavailable or unsupported and reuse a single protocol instance during transfer.

Bug Fixes:
- Guard the image transfer flow with an NFC availability check to avoid initiating transfers on devices without NFC support or with NFC disabled.

Enhancements:
- Introduce a reusable NFC availability helper on the protocol and share a single protocol instance between NFC validation and image transfer to streamline the transfer flow.