### PR TITLE
fix: gamma-correct grayscale before dithering 

### DIFF
--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -1,5 +1,6 @@
 use image::{load_from_memory_with_format, ImageFormat, RgbaImage, Rgba};
 use std::io::Cursor;
+use std::sync::OnceLock;
 
 pub enum DitherMethod {
     FloydSteinberg,
@@ -40,6 +41,24 @@ const PALETTE_BWR: [Colorf32; 3] = [
     Colorf32 { r: 255.0, g: 0.0, b: 0.0 },
 ];
 
+const DITHER_GAMMA: f32 = 1.5;
+
+#[inline(always)]
+fn apply_dither_gamma(c: f32) -> f32 {
+    (c / 255.0).powf(DITHER_GAMMA) * 255.0
+}
+
+fn dither_gamma_lut() -> &'static [f32; 256] {
+    static LUT: OnceLock<[f32; 256]> = OnceLock::new();
+    LUT.get_or_init(|| {
+        let mut lut = [0.0f32; 256];
+        for (i, v) in lut.iter_mut().enumerate() {
+            *v = apply_dither_gamma(i as f32);
+        }
+        lut
+    })
+}
+
 fn closest_color(pixel: Colorf32, palette: &[Colorf32]) -> Colorf32 {
     let mut min_dist = f32::MAX;
     let mut best_color = palette[0];
@@ -79,6 +98,15 @@ pub fn process_image_rust(
 
     let mut buffer: Vec<Colorf32> = img.pixels()
         .map(|p| Colorf32 { r: p[0] as f32, g: p[1] as f32, b: p[2] as f32 }).collect();
+
+    if !matches!(method, DitherMethod::Threshold) {
+        let gamma_lut = dither_gamma_lut();
+        for px in buffer.iter_mut() {
+            px.r = gamma_lut[px.r.clamp(0.0, 255.0) as usize];
+            px.g = gamma_lut[px.g.clamp(0.0, 255.0) as usize];
+            px.b = gamma_lut[px.b.clamp(0.0, 255.0) as usize];
+        }
+    }
 
     let palette = if is_bwr { &PALETTE_BWR[..] } else { &PALETTE_BW[..] };
 


### PR DESCRIPTION
Fixes #528 

## Changes

 - Convert pixels to real brightness (gamma 1.5) before dithering, in rust/src/api/simple.rs.                                                                                     
 - Works for both black/white and black/white/red modes.  
 
> Note: The "Posterize" filter is left out of this change on purpose. It just splits pixels into pure black or white at a cutoff it has no dithering. If we darkened it like others the whole image would turn almost fully black. It already looks right as-is.
 
## Screenshots 
> BEFORE 

<img width="1280" height="960" alt="WhatsApp Image 2026-07-16 at 2 06 41 AM" src="https://github.com/user-attachments/assets/676a8f51-4ace-4dff-883a-0c302b54398b" />
<img width="738" height="1600" alt="WhatsApp Image 2026-07-16 at 2 06 40 AM" src="https://github.com/user-attachments/assets/8b5b87c6-30ca-41a8-abf1-079d8a8258d4" />



> AFTER 


<img width="1280" height="805" alt="WhatsApp Image 2026-07-16 at 2 08 46 AM (1)" src="https://github.com/user-attachments/assets/443b14ee-7a89-4f9a-8713-33e6aac159b7" />
<img width="738" height="1600" alt="WhatsApp Image 2026-07-16 at 2 08 46 AM" src="https://github.com/user-attachments/assets/4908b083-2490-42a9-ace3-0bcf842d110f" />


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Correct grayscale brightness handling during dithering for both black/white and black/white/red modes by converting sRGB values to gamma-adjusted brightness first.

## Summary by Sourcery

Apply gamma-corrected brightness to image data before dithering to improve grayscale and B/W/R output.

Bug Fixes:
- Fix incorrect grayscale brightness handling during non-threshold dithering modes by converting pixel values to gamma-adjusted brightness first.

Enhancements:
- Introduce a reusable gamma correction constant and lookup to standardize brightness conversion for dithering.