### PR TITLE
fix: prevent color picker dialog from expanding to full width

### DIFF
--- a/lib/view/widget/configurable_epd_dialog.dart
+++ b/lib/view/widget/configurable_epd_dialog.dart
@@ -289,25 +289,26 @@ class _ConfigurableEpdDialogState extends State<ConfigurableEpdDialog> {
       return;
     }
     final pickedColor = await showDialog<Color>(
-        context: context,
-        builder: (context) => AlertDialog(
-              title: Text(appLocalizations.selectAColor),
-              content: SizedBox(
-                width: double.maxFinite,
-                child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: available.length,
-                  itemBuilder: (context, index) {
-                    final color = available[index];
-                    return ListTile(
-                      leading: CircleAvatar(backgroundColor: color),
-                      title: Text(ColorUtils.getColorDisplayName(color)),
-                      onTap: () => Navigator.of(context).pop(color),
-                    );
-                  },
-                ),
-              ),
-            ));
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(appLocalizations.selectAColor),
+        content: SizedBox(
+          width: 350,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: available.length,
+            itemBuilder: (context, index) {
+              final color = available[index];
+              return ListTile(
+                leading: CircleAvatar(backgroundColor: color),
+                title: Text(ColorUtils.getColorDisplayName(color)),
+                onTap: () => Navigator.of(context).pop(color),
+              );
+            },
+          ),
+        ),
+      ),
+    );
 
     if (pickedColor != null) {
       if (!mounted) return;


### PR DESCRIPTION
Fixes #539

## Changes
replace double.maxFinite with fixed dialog width

## Screenshots / Recordings
desktop:

https://github.com/user-attachments/assets/339c90fe-6a83-46cd-b203-c36d96873d97

mobile:

<img height="720" alt="Screenshot_20260720-042045 Magic ePaper" src="https://github.com/user-attachments/assets/2fda05ad-a2cc-4086-9d55-ef9e8dfcfec6" />


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Fix the color picker dialog layout so it no longer stretches to the maximum available width.