### PR TITLE
chore: upgrade Flutter to 3.44.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=3.3.4 <4.0.0"
-  flutter: '3.44.4'
+  flutter: '3.44.6'
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR updates Flutter version in pubspec.yaml to the latest stable release.

## Summary by Sourcery

Build:
- Update Flutter version requirement in pubspec.yaml to 3.44.6.