### PR TITLE
Add experimental support for Gicisky/Picksmart BLE ESL

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,16 @@
 
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
+    <!-- Bluetooth for Gicisky / Picksmart ESL support -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+
     <uses-feature android:name="android.hardware.nfc" android:required="true" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
     
     <application
         android:label="Magic ePaper"

--- a/lib/util/epd/gicisky/gicisky_ble_protocol.dart
+++ b/lib/util/epd/gicisky/gicisky_ble_protocol.dart
@@ -1,0 +1,208 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:logger/logger.dart';
+
+/// BLE protocol for Gicisky / Picksmart ESL tags.
+///
+/// GATT characteristics (16-bit UUIDs under the standard base):
+/// - Request / notify: 0xFEF1
+/// - Image data:       0xFEF2
+///
+/// Protocol flow (from reverse engineering):
+/// 1. Request block size (0x01)
+/// 2. Request write screen with image size (0x02 + 4-byte LE size)
+/// 3. Request start transfer (0x03)
+/// 4. On notify 0x05 + part index, send image block
+/// 5. On notify 0x05 0x08, transfer complete
+class GiciskyBleProtocol {
+  static final Guid requestCharacteristicUuid =
+      Guid('0000fef1-0000-1000-8000-00805f9b34fb');
+  static final Guid imageCharacteristicUuid =
+      Guid('0000fef2-0000-1000-8000-00805f9b34fb');
+
+  static final Logger _log = Logger();
+
+  final BluetoothDevice device;
+  final Uint8List imageData;
+  final void Function(double progress, String status)? onProgress;
+
+  int? _blockSize;
+  StreamSubscription<List<int>>? _notifySub;
+  final _transferCompleter = Completer<void>();
+  final _blockRequestController = StreamController<int?>.broadcast();
+
+  GiciskyBleProtocol({
+    required this.device,
+    required this.imageData,
+    this.onProgress,
+  });
+
+  Future<void> transfer() async {
+    onProgress?.call(0.0, 'Connecting...');
+    await device.connect(timeout: const Duration(seconds: 15));
+    try {
+      onProgress?.call(0.05, 'Discovering services...');
+      final services = await device.discoverServices();
+
+      BluetoothCharacteristic? requestChar;
+      BluetoothCharacteristic? imageChar;
+
+      for (final service in services) {
+        for (final c in service.characteristics) {
+          if (c.uuid == requestCharacteristicUuid) requestChar = c;
+          if (c.uuid == imageCharacteristicUuid) imageChar = c;
+        }
+      }
+
+      if (requestChar == null || imageChar == null) {
+        throw Exception(
+          'Gicisky characteristics (0xFEF1 / 0xFEF2) not found. '
+          'Is this a supported Picksmart / Gicisky ESL?',
+        );
+      }
+
+      onProgress?.call(0.1, 'Subscribing to notifications...');
+      await requestChar.setNotifyValue(true);
+      _notifySub = requestChar.onValueReceived.listen((data) {
+        _handleNotify(data, imageChar!);
+      });
+
+      onProgress?.call(0.15, 'Requesting block size...');
+      await _writeRequest(requestChar, [0x01]);
+      await _waitForBlockSize();
+
+      onProgress?.call(0.2, 'Requesting screen write...');
+      final sizeBytes = _intToLe(imageData.length, 4);
+      await _writeRequest(requestChar, [0x02, ...sizeBytes]);
+
+      onProgress?.call(0.25, 'Starting transfer...');
+      await _writeRequest(requestChar, [0x03]);
+
+      // Drive the transfer via notify-driven block requests
+      await _transferCompleter.future.timeout(
+        const Duration(minutes: 3),
+        onTimeout: () => throw TimeoutException('Image transfer timed out'),
+      );
+
+      onProgress?.call(1.0, 'Transfer complete');
+    } finally {
+      await _notifySub?.cancel();
+      try {
+        await device.disconnect();
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _writeRequest(
+    BluetoothCharacteristic char,
+    List<int> data,
+  ) async {
+    await char.write(data, withoutResponse: false);
+  }
+
+  Future<void> _waitForBlockSize() async {
+    // Block size arrives via notify 0x01
+    final completer = Completer<void>();
+    late StreamSubscription sub;
+    sub = _blockRequestController.stream.listen((_) {
+      if (_blockSize != null && !completer.isCompleted) {
+        completer.complete();
+        sub.cancel();
+      }
+    });
+    // Also poll briefly in case notify already arrived
+    for (var i = 0; i < 50 && _blockSize == null; i++) {
+      await Future.delayed(const Duration(milliseconds: 50));
+    }
+    if (_blockSize == null) {
+      await completer.future.timeout(const Duration(seconds: 10));
+    }
+  }
+
+  void _handleNotify(List<int> data, BluetoothCharacteristic imageChar) {
+    if (data.isEmpty) return;
+    _log.d('Gicisky notify: $data');
+
+    switch (data[0]) {
+      case 0x01:
+        if (data.length >= 3) {
+          _blockSize = data[1] | (data[2] << 8);
+          _log.i('Block size: $_blockSize');
+          _blockRequestController.add(null);
+        }
+        break;
+      case 0x02:
+        if (data.length > 1 && data[1] != 0x00) {
+          _fail('Write screen rejected: ${data[1]}');
+        }
+        break;
+      case 0x05:
+        if (data.length < 2) break;
+        if (data[1] == 0x00 && data.length >= 6) {
+          final part = data[2] |
+              (data[3] << 8) |
+              (data[4] << 16) |
+              (data[5] << 24);
+          _sendImageBlock(imageChar, part);
+        } else if (data[1] == 0x08) {
+          if (!_transferCompleter.isCompleted) {
+            _transferCompleter.complete();
+          }
+        } else {
+          _fail('Image transfer error: ${data[1]}');
+        }
+        break;
+      default:
+        _log.w('Unknown notify opcode: ${data[0]}');
+    }
+  }
+
+  Future<void> _sendImageBlock(
+    BluetoothCharacteristic imageChar,
+    int part,
+  ) async {
+    final blockSize = _blockSize;
+    if (blockSize == null || blockSize <= 4) {
+      _fail('Invalid block size');
+      return;
+    }
+    final imgBlockSize = blockSize - 4;
+    final numParts = (imageData.length + imgBlockSize - 1) ~/ imgBlockSize;
+    if (part >= numParts) {
+      _fail('Part $part out of range (max $numParts)');
+      return;
+    }
+
+    final start = part * imgBlockSize;
+    final end = (start + imgBlockSize).clamp(0, imageData.length);
+    final slice = imageData.sublist(start, end);
+
+    final message = BytesBuilder();
+    message.add(_intToLe(part, 4));
+    message.add(slice);
+
+    final progress = 0.25 + 0.7 * ((part + 1) / numParts);
+    onProgress?.call(
+      progress.clamp(0.0, 0.95),
+      'Sending part ${part + 1}/$numParts',
+    );
+
+    await imageChar.write(message.toBytes(), withoutResponse: false);
+  }
+
+  void _fail(String message) {
+    if (!_transferCompleter.isCompleted) {
+      _transferCompleter.completeError(Exception(message));
+    }
+  }
+
+  List<int> _intToLe(int value, int byteCount) {
+    final bytes = <int>[];
+    for (var i = 0; i < byteCount; i++) {
+      bytes.add((value >> (8 * i)) & 0xff);
+    }
+    return bytes;
+  }
+}

--- a/lib/util/epd/gicisky/gicisky_display.dart
+++ b/lib/util/epd/gicisky/gicisky_display.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:image/image.dart' as img;
+import 'package:magicepaperapp/constants/asset_paths.dart';
+import 'package:magicepaperapp/util/epd/display_device.dart';
+import 'package:magicepaperapp/util/epd/driver/waveform.dart';
+import 'package:magicepaperapp/util/epd/gicisky/gicisky_ble_protocol.dart';
+import 'package:magicepaperapp/util/epd/gicisky/gicisky_encoder.dart';
+import 'package:magicepaperapp/util/image_processing/image_processing.dart';
+import 'package:magicepaperapp/view/widget/transfer_progress_dialog.dart';
+
+/// Experimental support for ATC GICISKY / Picksmart BLE electronic shelf labels.
+///
+/// Primary target: 2.1" 250x122 BWR model (common Picksmart tag).
+/// Protocol based on reverse engineering by atc1441 and the gicisky-tag project.
+///
+/// Requires Bluetooth permissions and a real device for verification.
+class Gicisky250x122Bwr extends DisplayDevice {
+  @override
+  String get name => 'Gicisky / Picksmart 2.1" BWR (BLE)';
+
+  @override
+  String get modelId => 'GICISKY-250x122-BWR';
+
+  @override
+  String get imgPath => ImageAssets.waveshare2_13; // reuse similar aspect
+
+  @override
+  int get width => 250;
+
+  @override
+  int get height => 122;
+
+  @override
+  List<Color> get colors => [Colors.white, Colors.black, Colors.red];
+
+  @override
+  List<String>? get displayChips => ['Gicisky / Picksmart BLE ESL'];
+
+  @override
+  List<ImageProcessingMethod> get processingMethods => [
+        ImageProcessing.bwrFloydSteinbergDither,
+        ImageProcessing.bwrFalseFloydSteinbergDither,
+        ImageProcessing.bwrStuckiDither,
+        ImageProcessing.bwrTriColorAtkinsonDither,
+        ImageProcessing.bwrHalftone,
+        ImageProcessing.bwrThreshold,
+        ImageProcessing.bwrBayerDither,
+        ImageProcessing.bwrSierra2Dither,
+        ImageProcessing.bwrBurkesDither,
+      ];
+
+  @override
+  Future<void> transfer(
+    BuildContext context,
+    img.Image image, {
+    Waveform? waveform,
+  }) async {
+    if (!context.mounted) return;
+
+    await TransferProgressDialog.show(
+      context: context,
+      finalImg: image,
+      transferFunction: (imgData, onProgress, onTagDetected) async {
+        onProgress(0.0, 'Scanning for Gicisky / Picksmart tag...');
+
+        // Ensure Bluetooth is on
+        if (await FlutterBluePlus.isSupported == false) {
+          throw Exception('Bluetooth is not supported on this device');
+        }
+
+        final adapterState = await FlutterBluePlus.adapterState.first;
+        if (adapterState != BluetoothAdapterState.on) {
+          throw Exception('Please turn on Bluetooth');
+        }
+
+        BluetoothDevice? target;
+        final subscription = FlutterBluePlus.onScanResults.listen((results) {
+          for (final r in results) {
+            final name = r.device.platformName.toUpperCase();
+            final adv = r.advertisementData;
+            // Picksmart often advertises as PICKSMART or NEMR...
+            // Manufacturer ID 20563 (0x5053) is used by some tags.
+            final isCandidate = name.startsWith('PICKSMART') ||
+                name.startsWith('NEMR') ||
+                name.startsWith('GICISKY') ||
+                adv.manufacturerData.keys.contains(20563) ||
+                r.device.remoteId.str.toUpperCase().startsWith('FF:FF');
+            if (isCandidate) {
+              target = r.device;
+              FlutterBluePlus.stopScan();
+              break;
+            }
+          }
+        });
+
+        await FlutterBluePlus.startScan(timeout: const Duration(seconds: 12));
+        await Future.delayed(const Duration(seconds: 12));
+        await subscription.cancel();
+        await FlutterBluePlus.stopScan();
+
+        if (target == null) {
+          throw Exception(
+            'No Gicisky / Picksmart tag found. '
+            'Make sure the tag is powered and in range.',
+          );
+        }
+
+        onTagDetected();
+        onProgress(0.1, 'Encoding image...');
+
+        final encoded = GiciskyEncoder.encode(
+          imgData,
+          width: width,
+          height: height,
+        );
+
+        final protocol = GiciskyBleProtocol(
+          device: target!,
+          imageData: encoded,
+          onProgress: onProgress,
+        );
+
+        await protocol.transfer();
+      },
+      colorAccent: Colors.red,
+    );
+  }
+}

--- a/lib/util/epd/gicisky/gicisky_encoder.dart
+++ b/lib/util/epd/gicisky/gicisky_encoder.dart
@@ -1,0 +1,115 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+/// Encodes images for Gicisky / Picksmart BLE ESL tags.
+///
+/// Based on the reverse-engineered format used by atc1441 and the
+/// gicisky-tag Python library. Currently targets the common
+/// 250x122 BWR (black/white/red) model using uncompressed line data.
+///
+/// Image layout after rotation: width=250, height=122.
+class GiciskyEncoder {
+  static const List<int> _black = [0, 0, 0];
+  static const List<int> _white = [255, 255, 255];
+  static const List<int> _red = [255, 0, 0];
+
+  /// Encode a processed BWR image into the payload expected by the tag.
+  ///
+  /// [image] should already be sized to [width] x [height] and contain
+  /// only black, white and red pixels (dithered).
+  static Uint8List encode(
+    img.Image image, {
+    int width = 250,
+    int height = 122,
+  }) {
+    if (image.width != width || image.height != height) {
+      image = img.copyResize(image, width: width, height: height);
+    }
+
+    // Build bitmaps: true = white (for BW plane), true = red (for red plane).
+    // After rotation the Python code expects shape (width, height) with
+    // columns packed.
+    final bwBitmap = List.generate(width, (_) => List.filled(height, false));
+    final redBitmap = List.generate(width, (_) => List.filled(height, false));
+
+    for (var y = 0; y < height; y++) {
+      for (var x = 0; x < width; x++) {
+        final p = image.getPixel(x, y);
+        final r = p.r.toInt();
+        final g = p.g.toInt();
+        final b = p.b.toInt();
+
+        final isRed = _isCloser(r, g, b, _red);
+        final isWhite = !isRed && _isCloser(r, g, b, _white);
+
+        // Rotate 90° CCW equivalent used by reference: flipud + rot90
+        // Here we store column-major as the compressor expects.
+        final col = x;
+        final row = height - 1 - y;
+        bwBitmap[col][row] = isWhite;
+        redBitmap[col][row] = isRed;
+      }
+    }
+
+    final bwData = _compressBitmap(bwBitmap, width, height);
+    final redData = _compressBitmap(redBitmap, width, height);
+
+    final payload = BytesBuilder();
+    final totalLen = bwData.length + redData.length;
+    payload.add(_intToLittleEndian(totalLen, 4));
+    payload.add(bwData);
+    payload.add(redData);
+    return payload.toBytes();
+  }
+
+  static bool _isCloser(int r, int g, int b, List<int> target) {
+    final dr = r - target[0];
+    final dg = g - target[1];
+    final db = b - target[2];
+    final dist = dr * dr + dg * dg + db * db;
+    // Simple threshold: closer to target than to the other primaries
+    return dist < 20000;
+  }
+
+  /// Uncompressed line encoding used by the Python reference
+  /// (compression markers all zero).
+  static Uint8List _compressBitmap(
+    List<List<bool>> bitmap,
+    int width,
+    int height,
+  ) {
+    final numLineBytes = math.ceil(height / 8).toInt();
+    final out = BytesBuilder();
+    const compressionMarkers = [0, 0, 0, 0];
+
+    for (var col = 0; col < width; col++) {
+      final lineBytes = List<int>.filled(numLineBytes, 0);
+      for (var row = 0; row < height; row++) {
+        if (bitmap[col][row]) {
+          final byteIndex = row ~/ 8;
+          final bitIndex = 7 - (row % 8);
+          lineBytes[byteIndex] |= 1 << bitIndex;
+        }
+      }
+
+      // 0x75 | length | num_line_bytes | markers | line data
+      final lineLen = 3 + compressionMarkers.length + lineBytes.length;
+      out.addByte(0x75);
+      out.addByte(lineLen);
+      out.addByte(numLineBytes);
+      out.add(compressionMarkers);
+      out.add(lineBytes);
+    }
+    return out.toBytes();
+  }
+
+  static Uint8List _intToLittleEndian(int value, int byteCount) {
+    final bytes = Uint8List(byteCount);
+    for (var i = 0; i < byteCount; i++) {
+      bytes[i] = (value >> (8 * i)) & 0xff;
+    }
+    return bytes;
+  }
+}

--- a/lib/view/display_selection_screen.dart
+++ b/lib/view/display_selection_screen.dart
@@ -7,6 +7,7 @@ import 'package:magicepaperapp/util/epd/display_device.dart';
 import 'package:magicepaperapp/util/epd/gdeq031t10.dart';
 import 'package:magicepaperapp/util/epd/gdey037z03.dart';
 import 'package:magicepaperapp/util/epd/gdey037z03bw.dart';
+import 'package:magicepaperapp/util/epd/gicisky/gicisky_display.dart';
 import 'package:magicepaperapp/util/epd/waveshare_displays.dart';
 import 'package:magicepaperapp/view/image_editor.dart';
 import 'package:magicepaperapp/view/widget/common_scaffold_widget.dart';
@@ -33,6 +34,8 @@ class _DisplaySelectionScreenState extends State<DisplaySelectionScreen> {
     Waveshare4in2(),
     Waveshare7in5(),
     Waveshare7in5HD(),
+    // Experimental BLE ESL support (issue #182)
+    Gicisky250x122Bwr(),
   ];
 
   static const double _scrollbarGutter = 16.0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   ndef: ^0.4.0
   logger: ^2.4.0
   ffi: ^2.2.0
+  flutter_blue_plus: ^1.35.3
   rust_lib_magicepaperapp:
     path: rust_builder
   flutter_rust_bridge: 2.12.0


### PR DESCRIPTION
Fixes #<!-- Add issue number here. This will automatically close the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes
<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add experimental Bluetooth Low Energy support for Gicisky/Picksmart electronic shelf labels and expose a new display option in the app.

New Features:
- Introduce GiciskyBleProtocol to handle BLE image transfer to Gicisky/Picksmart ESL tags.
- Add Gicisky250x122Bwr display device with tri-color image processing and BLE-based transfer workflow.
- Provide a GiciskyEncoder to convert processed BWR images into the ESL tag payload format.
- Add a new experimental Gicisky / Picksmart 2.1" BWR (BLE) display entry to the display selection screen.

Enhancements:
- Declare necessary Android Bluetooth and location permissions and optional BLE hardware feature for ESL support.
- Add flutter_blue_plus dependency to enable BLE communication with ESL tags.

Build:
- Add flutter_blue_plus package to pubspec dependencies for BLE support.