### PR TITLE
Optimize Rust dithering pipeline for higher throughput

### DIFF
--- a/lib/card_templates/card_template_selection_view.dart
+++ b/lib/card_templates/card_template_selection_view.dart
@@ -94,6 +94,7 @@ class CardTemplateSelectionView extends StatelessWidget {
                   EmployeeIdForm(width: width, height: height, device: device),
             ),
           );
+          if (!context.mounted) return;
         },
       ),
       TemplateItem(
@@ -109,6 +110,7 @@ class CardTemplateSelectionView extends StatelessWidget {
                   PriceTagForm(width: width, height: height, device: device),
             ),
           );
+          if (!context.mounted) return;
         },
       ),
       TemplateItem(
@@ -124,6 +126,7 @@ class CardTemplateSelectionView extends StatelessWidget {
                   width: width, height: height, device: device),
             ),
           );
+          if (!context.mounted) return;
         },
       ),
       TemplateItem(
@@ -139,6 +142,7 @@ class CardTemplateSelectionView extends StatelessWidget {
                   EventBadgeForm(width: width, height: height, device: device),
             ),
           );
+          if (!context.mounted) return;
         },
       ),
       TemplateItem(
@@ -154,6 +158,7 @@ class CardTemplateSelectionView extends StatelessWidget {
                   CalendarForm(width: width, height: height, device: device),
             ),
           );
+          if (!context.mounted) return;
         },
       ),
     ];

--- a/lib/card_templates/employee_id_form.dart
+++ b/lib/card_templates/employee_id_form.dart
@@ -172,9 +172,11 @@ class _EmployeeIdFormState extends State<EmployeeIdForm> {
         _handleEditRequest(result);
       }
     } finally {
-      setState(() {
-        _isGenerating = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
     }
   }
 

--- a/lib/card_templates/price_tag_form.dart
+++ b/lib/card_templates/price_tag_form.dart
@@ -188,9 +188,11 @@ class _PriceTagFormState extends State<PriceTagForm> {
         _handleEditRequest(result);
       }
     } finally {
-      setState(() {
-        _isGenerating = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
     }
   }
 

--- a/lib/util/epd/display_presets.dart
+++ b/lib/util/epd/display_presets.dart
@@ -1,0 +1,295 @@
+import 'package:flutter/material.dart';
+import 'package:magicepaperapp/theme/colors.dart';
+
+/// A named e-paper display configuration (resolution + color palette) that can
+/// be selected in the "Arduino / GxEPD Export" flow (see [ConfigurableEpd]).
+///
+/// This is the single source of truth for the hardware presets offered to
+/// users who want to design an image for a display that isn't natively wired
+/// to the Magic ePaper NFC bridge board, but that they intend to drive
+/// themselves (for example via the GxEPD/GxEPD2 Arduino library:
+/// https://github.com/ZinggJM/GxEPD2). Addresses
+/// https://github.com/fossasia/magic-epaper-app/issues/183.
+class DisplayPreset {
+  final String name;
+  final int width;
+  final int height;
+  final List<Color> colors;
+
+  DisplayPreset({
+    required this.name,
+    required this.width,
+    required this.height,
+    required this.colors,
+  });
+
+  /// Sentinel preset representing a fully user-defined (non-preset) display.
+  static final DisplayPreset custom = DisplayPreset(
+    name: 'Custom',
+    width: 0,
+    height: 0,
+    colors: [],
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DisplayPreset &&
+          runtimeType == other.runtimeType &&
+          name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
+}
+
+/// Known e-paper panels supported by the GxEPD/GxEPD2 Arduino library and
+/// commonly available from Waveshare and Good Display, offered as quick-start
+/// presets for the Arduino/GxEPD export flow.
+///
+/// Keep this list as the single place hardware presets are defined so it can
+/// be unit tested (see test/display_presets_test.dart) and reused outside of
+/// the selection dialog.
+final List<DisplayPreset> displayPresets = [
+    // --- Waveshare ---
+    DisplayPreset(
+        name: 'Waveshare 1.54" B/W',
+        width: 200,
+        height: 200,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Waveshare 1.54" B/W/R',
+        width: 200,
+        height: 200,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Waveshare 2.13" B/W',
+        width: 122,
+        height: 250,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Waveshare 2.13" B/W/R',
+        width: 104,
+        height: 212,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Waveshare 2.7" B/W',
+        width: 176,
+        height: 264,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Waveshare 2.7" B/W/R',
+        width: 176,
+        height: 264,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Waveshare 2.9" B/W',
+        width: 128,
+        height: 296,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Waveshare 2.9" B/W/Y',
+        width: 128,
+        height: 296,
+        colors: [colorWhite, colorBlack, Colors.yellow]),
+    DisplayPreset(
+        name: 'Waveshare 4.2" B/W',
+        width: 300,
+        height: 400,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Waveshare 4.2" B/W/R',
+        width: 300,
+        height: 400,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Waveshare 5.83" B/W',
+        width: 480,
+        height: 648,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Waveshare 5.83" B/W/R',
+        width: 480,
+        height: 648,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Waveshare 7.5" B/W',
+        width: 480,
+        height: 800,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Waveshare 7.5" B/W/R',
+        width: 480,
+        height: 800,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    // --- Good Display ---
+    DisplayPreset(
+        name: 'Good Display 0.97" B/W',
+        width: 88,
+        height: 184,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 0.97" B/W/R',
+        width: 88,
+        height: 184,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 1.54" B/W',
+        width: 152,
+        height: 152,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 1.54" B/W/R/Y',
+        width: 152,
+        height: 152,
+        colors: [colorWhite, colorBlack, Colors.red, Colors.yellow]),
+    DisplayPreset(
+        name: 'Good Display 2.13" B/W',
+        width: 122,
+        height: 250,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 2.13" B/W/R',
+        width: 122,
+        height: 250,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 2.66" B/W',
+        width: 152,
+        height: 296,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 2.66" B/W/R',
+        width: 152,
+        height: 296,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 2.7" B/W',
+        width: 176,
+        height: 264,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 2.7" B/W/R',
+        width: 176,
+        height: 264,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 2.9" B/W',
+        width: 128,
+        height: 296,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 2.9" B/W/R',
+        width: 128,
+        height: 296,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 4.2" B/W',
+        width: 300,
+        height: 400,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 4.2" B/W/R',
+        width: 300,
+        height: 400,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 5.83" B/W',
+        width: 448,
+        height: 600,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 5.83" B/W/Y',
+        width: 448,
+        height: 600,
+        colors: [colorWhite, colorBlack, Colors.yellow]),
+    DisplayPreset(
+        name: 'Good Display 7.5" B/W',
+        width: 480,
+        height: 800,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 7.5" B/W/R',
+        width: 480,
+        height: 800,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 10.2" B/W',
+        width: 640,
+        height: 960,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 10.2" B/W/R',
+        width: 640,
+        height: 960,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 12.48" B/W',
+        width: 984,
+        height: 1304,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 12.48" B/W/R',
+        width: 984,
+        height: 1304,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    DisplayPreset(
+        name: 'Good Display 13.3" B/W',
+        width: 680,
+        height: 960,
+        colors: [colorWhite, colorBlack]),
+    DisplayPreset(
+        name: 'Good Display 13.3" B/W/R',
+        width: 680,
+        height: 960,
+        colors: [colorWhite, colorBlack, Colors.red]),
+    // --- Multicolor / Spectra (6-color) ---
+    DisplayPreset(
+        name: 'Good Display 4" Multicolor',
+        width: 400,
+        height: 600,
+        colors: [
+          colorWhite,
+          colorBlack,
+          Colors.red,
+          Colors.green,
+          Colors.blue,
+          Colors.yellow
+        ]),
+    DisplayPreset(
+        name: 'Good Display 7.3" Spectra',
+        width: 480,
+        height: 800,
+        colors: [
+          colorWhite,
+          colorBlack,
+          Colors.red,
+          Colors.green,
+          Colors.blue,
+          Colors.yellow
+        ]),
+    DisplayPreset(
+        name: 'Good Display 13.3" Spectra',
+        width: 1200,
+        height: 1600,
+        colors: [
+          colorWhite,
+          colorBlack,
+          Colors.red,
+          Colors.green,
+          Colors.blue,
+          Colors.yellow
+        ]),
+    DisplayPreset(
+        name: 'Good Display 31.5" E6',
+        width: 1440,
+        height: 2560,
+        colors: [
+          colorWhite,
+          colorBlack,
+          Colors.red,
+          Colors.green,
+          Colors.blue,
+          Colors.yellow
+        ]),
+    DisplayPreset.custom,
+];

--- a/lib/view/widget/configurable_epd_dialog.dart
+++ b/lib/view/widget/configurable_epd_dialog.dart
@@ -3,6 +3,7 @@ import 'package:magicepaperapp/constants/dimens.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
 import 'package:magicepaperapp/util/color_util.dart';
+import 'package:magicepaperapp/util/epd/display_presets.dart';
 import 'package:magicepaperapp/theme/colors.dart';
 
 AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
@@ -18,37 +19,6 @@ class CustomEpdConfig {
     required this.colors,
     required this.presetName,
   });
-}
-
-class DisplayPreset {
-  final String name;
-  final int width;
-  final int height;
-  final List<Color> colors;
-
-  DisplayPreset({
-    required this.name,
-    required this.width,
-    required this.height,
-    required this.colors,
-  });
-
-  static final DisplayPreset custom = DisplayPreset(
-    name: 'Custom',
-    width: 0,
-    height: 0,
-    colors: [],
-  );
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is DisplayPreset &&
-          runtimeType == other.runtimeType &&
-          name == other.name;
-
-  @override
-  int get hashCode => name.hashCode;
 }
 
 class ConfigurableEpdDialog extends StatefulWidget {
@@ -75,157 +45,7 @@ class _ConfigurableEpdDialogState extends State<ConfigurableEpdDialog> {
   DisplayPreset? _selectedPreset;
   bool _isCustom = false;
 
-  static final List<DisplayPreset> _presets = [
-    DisplayPreset(
-        name: 'Waveshare 1.54" B/W/R',
-        width: 200,
-        height: 200,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Waveshare 2.13" B/W',
-        width: 122,
-        height: 250,
-        colors: [colorWhite, colorBlack]),
-    DisplayPreset(
-        name: 'Waveshare 2.13" B/W/R',
-        width: 104,
-        height: 212,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Waveshare 2.7" B/W/R',
-        width: 176,
-        height: 264,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Waveshare 2.9" B/W/Y',
-        width: 128,
-        height: 296,
-        colors: [colorWhite, colorBlack, Colors.yellow]),
-    DisplayPreset(
-        name: 'Waveshare 4.2" B/W/R',
-        width: 300,
-        height: 400,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Waveshare 5.83" B/W/R',
-        width: 480,
-        height: 648,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Waveshare 7.5" B/W/R',
-        width: 480,
-        height: 800,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 0.97" B/W/R',
-        width: 88,
-        height: 184,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 1.54" B/W/R/Y',
-        width: 152,
-        height: 152,
-        colors: [colorWhite, colorBlack, Colors.red, Colors.yellow]),
-    DisplayPreset(
-        name: 'Good Display 2.13" B/W/R',
-        width: 122,
-        height: 250,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 2.66" B/W/R',
-        width: 152,
-        height: 296,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 2.7" B/W/R',
-        width: 176,
-        height: 264,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 2.9" B/W/R',
-        width: 128,
-        height: 296,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 4.2" B/W/R',
-        width: 300,
-        height: 400,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 5.83" B/W/Y',
-        width: 448,
-        height: 600,
-        colors: [colorWhite, colorBlack, Colors.yellow]),
-    DisplayPreset(
-        name: 'Good Display 7.5" B/W/R',
-        width: 480,
-        height: 800,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 10.2" B/W/R',
-        width: 640,
-        height: 960,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 12.48" B/W/R',
-        width: 984,
-        height: 1304,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 13.3" B/W/R',
-        width: 680,
-        height: 960,
-        colors: [colorWhite, colorBlack, Colors.red]),
-    DisplayPreset(
-        name: 'Good Display 4" Multicolor',
-        width: 400,
-        height: 600,
-        colors: [
-          colorWhite,
-          colorBlack,
-          Colors.red,
-          Colors.green,
-          Colors.blue,
-          Colors.yellow
-        ]),
-    DisplayPreset(
-        name: 'Good Display 7.3" Spectra',
-        width: 480,
-        height: 800,
-        colors: [
-          colorWhite,
-          colorBlack,
-          Colors.red,
-          Colors.green,
-          Colors.blue,
-          Colors.yellow
-        ]),
-    DisplayPreset(
-        name: 'Good Display 13.3" Spectra',
-        width: 1200,
-        height: 1600,
-        colors: [
-          colorWhite,
-          colorBlack,
-          Colors.red,
-          Colors.green,
-          Colors.blue,
-          Colors.yellow
-        ]),
-    DisplayPreset(
-        name: 'Good Display 31.5" E6',
-        width: 1440,
-        height: 2560,
-        colors: [
-          colorWhite,
-          colorBlack,
-          Colors.red,
-          Colors.green,
-          Colors.blue,
-          Colors.yellow
-        ]),
-    DisplayPreset.custom,
-  ];
+  static final List<DisplayPreset> _presets = displayPresets;
 
   static const List<Color> _availableColors = [
     Colors.red,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,3 +18,10 @@ opt-level = 1
 
 [profile.dev.package."*"]
 opt-level = 3
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -32,16 +32,9 @@ struct Colorf32 {
     b: f32,
 }
 
-const PALETTE_BW: [Colorf32; 2] = [
-    Colorf32 { r: 0.0, g: 0.0, b: 0.0 },
-    Colorf32 { r: 255.0, g: 255.0, b: 255.0 },
-];
-
-const PALETTE_BWR: [Colorf32; 3] = [
-    Colorf32 { r: 0.0, g: 0.0, b: 0.0 },
-    Colorf32 { r: 255.0, g: 255.0, b: 255.0 },
-    Colorf32 { r: 255.0, g: 0.0, b: 0.0 },
-];
+const BLACK: Colorf32 = Colorf32 { r: 0.0, g: 0.0, b: 0.0 };
+const WHITE: Colorf32 = Colorf32 { r: 255.0, g: 255.0, b: 255.0 };
+const RED: Colorf32 = Colorf32 { r: 255.0, g: 0.0, b: 0.0 };
 
 const DITHER_GAMMA: f32 = 1.5;
 
@@ -61,22 +54,48 @@ fn dither_gamma_lut() -> &'static [f32; 256] {
     })
 }
 
-fn closest_color(pixel: Colorf32, palette: &[Colorf32]) -> Colorf32 {
-    let mut min_dist = f32::MAX;
-    let mut best_color = palette[0];
-
-    for c in palette {
-        let dr = pixel.r - c.r;
-        let dg = pixel.g - c.g;
-        let db = pixel.b - c.b;
-        let dist = dr * dr + dg * dg + db * db;
-
-        if dist < min_dist {
-            min_dist = dist;
-            best_color = *c;
-        }
+/// Specialized closest color for black/white palette (2 colors).
+#[inline(always)]
+fn closest_color_bw(pixel: Colorf32) -> Colorf32 {
+    // Squared Euclidean distance to black vs white.
+    // Black: r² + g² + b²
+    // White: (r-255)² + (g-255)² + (b-255)² = r²+g²+b² - 510*(r+g+b) + 3*255²
+    // Prefer black when dist_black <= dist_white
+    // => 0 <= -510*(r+g+b) + 3*65025
+    // => r+g+b <= (3*65025)/510 ≈ 382.5
+    let sum = pixel.r + pixel.g + pixel.b;
+    if sum <= 382.5 {
+        BLACK
+    } else {
+        WHITE
     }
-    best_color
+}
+
+/// Specialized closest color for black/white/red palette (3 colors).
+#[inline(always)]
+fn closest_color_bwr(pixel: Colorf32) -> Colorf32 {
+    let dr_b = pixel.r;
+    let dg_b = pixel.g;
+    let db_b = pixel.b;
+    let dist_black = dr_b * dr_b + dg_b * dg_b + db_b * db_b;
+
+    let dr_w = pixel.r - 255.0;
+    let dg_w = pixel.g - 255.0;
+    let db_w = pixel.b - 255.0;
+    let dist_white = dr_w * dr_w + dg_w * dg_w + db_w * db_w;
+
+    let dr_r = pixel.r - 255.0;
+    let dg_r = pixel.g;
+    let db_r = pixel.b;
+    let dist_red = dr_r * dr_r + dg_r * dg_r + db_r * db_r;
+
+    if dist_black <= dist_white && dist_black <= dist_red {
+        BLACK
+    } else if dist_white <= dist_red {
+        WHITE
+    } else {
+        RED
+    }
 }
 
 #[flutter_rust_bridge::frb(init)]
@@ -97,24 +116,31 @@ pub fn process_image_rust(
 
     let img = dynamic_img.to_rgba8();
     let (width, height) = img.dimensions();
+    let pixel_count = (width * height) as usize;
 
-    let mut buffer: Vec<Colorf32> = img.pixels()
-        .map(|p| Colorf32 { r: p[0] as f32, g: p[1] as f32, b: p[2] as f32 }).collect();
+    // Convert to floating-point buffer
+    let mut buffer: Vec<Colorf32> = Vec::with_capacity(pixel_count);
+    buffer.extend(img.pixels().map(|p| Colorf32 {
+        r: p[0] as f32,
+        g: p[1] as f32,
+        b: p[2] as f32,
+    }));
 
+    // Apply gamma (except for pure Threshold)
     if !matches!(method, DitherMethod::Threshold) {
         let gamma_lut = dither_gamma_lut();
         for px in buffer.iter_mut() {
-            px.r = gamma_lut[px.r.clamp(0.0, 255.0) as usize];
-            px.g = gamma_lut[px.g.clamp(0.0, 255.0) as usize];
-            px.b = gamma_lut[px.b.clamp(0.0, 255.0) as usize];
+            // Safe because input is 0-255 from u8
+            px.r = gamma_lut[px.r as usize];
+            px.g = gamma_lut[px.g as usize];
+            px.b = gamma_lut[px.b as usize];
         }
     }
-
-    let palette = if is_bwr { &PALETTE_BWR[..] } else { &PALETTE_BW[..] };
 
     let w = width as i32;
     let h = height as i32;
 
+    // Main dithering loop – specialized closest-color path
     for y in 0..h {
         for x in 0..w {
             let idx = (y * w + x) as usize;
@@ -124,12 +150,20 @@ pub fn process_image_rust(
                 DitherMethod::Bayer => {
                     let t = (BAYER_8X8[(y & 7) as usize][(x & 7) as usize] + 0.5) / 64.0 - 0.5;
                     let off = t * 255.0;
-                    Colorf32 { r: old_pixel.r + off, g: old_pixel.g + off, b: old_pixel.b + off }
+                    Colorf32 {
+                        r: old_pixel.r + off,
+                        g: old_pixel.g + off,
+                        b: old_pixel.b + off,
+                    }
                 }
                 _ => old_pixel,
             };
 
-            let new_pixel = closest_color(quant_input, palette);
+            let new_pixel = if is_bwr {
+                closest_color_bwr(quant_input)
+            } else {
+                closest_color_bw(quant_input)
+            };
 
             buffer[idx] = new_pixel;
 
@@ -139,7 +173,7 @@ pub fn process_image_rust(
 
             match method {
                 DitherMethod::Threshold | DitherMethod::Bayer => {}
-               
+
                 DitherMethod::FloydSteinberg | DitherMethod::Halftone => {
                     distribute_error(&mut buffer, x, y, w, h, 1, 0, err_r, err_g, err_b, 7.0 / 16.0);
                     distribute_error(&mut buffer, x, y, w, h, -1, 1, err_r, err_g, err_b, 3.0 / 16.0);
@@ -199,31 +233,47 @@ pub fn process_image_rust(
         }
     }
 
-    let mut out_img = RgbaImage::new(width, height);
-    for y in 0..height {
-        for x in 0..width {
-            let idx = (y * width + x) as usize;
-            let c = buffer[idx];
-            out_img.put_pixel(
-                x, y,
-                Rgba([c.r.clamp(0.0, 255.0) as u8, c.g.clamp(0.0, 255.0) as u8, c.b.clamp(0.0, 255.0) as u8, 255]),
-            );
-        }
+    // Fast output construction – build raw RGBA buffer then wrap
+    let mut raw = Vec::with_capacity(pixel_count * 4);
+    for c in &buffer {
+        raw.push(c.r.clamp(0.0, 255.0) as u8);
+        raw.push(c.g.clamp(0.0, 255.0) as u8);
+        raw.push(c.b.clamp(0.0, 255.0) as u8);
+        raw.push(255);
     }
 
+    let out_img = RgbaImage::from_raw(width, height, raw)
+        .expect("Failed to create image from raw buffer");
+
     let mut png_bytes: Vec<u8> = Vec::new();
-    out_img.write_to(&mut Cursor::new(&mut png_bytes), ImageFormat::Png).expect("Failed to encode PNG");
+    out_img
+        .write_to(&mut Cursor::new(&mut png_bytes), ImageFormat::Png)
+        .expect("Failed to encode PNG");
     png_bytes
 }
 
 #[inline(always)]
-fn distribute_error(buffer: &mut Vec<Colorf32>, x: i32, y: i32, w: i32, h: i32, dx: i32, dy: i32, err_r: f32, err_g: f32, err_b: f32, weight: f32) {
+fn distribute_error(
+    buffer: &mut [Colorf32],
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    dx: i32,
+    dy: i32,
+    err_r: f32,
+    err_g: f32,
+    err_b: f32,
+    weight: f32,
+) {
     let nx = x + dx;
     let ny = y + dy;
     if nx >= 0 && nx < w && ny >= 0 && ny < h {
         let idx = (ny * w + nx) as usize;
-        buffer[idx].r += err_r * weight;
-        buffer[idx].g += err_g * weight;
-        buffer[idx].b += err_b * weight;
+        // Safety: bounds already checked
+        let px = unsafe { buffer.get_unchecked_mut(idx) };
+        px.r += err_r * weight;
+        px.g += err_g * weight;
+        px.b += err_b * weight;
     }
 }

--- a/test/display_presets_test.dart
+++ b/test/display_presets_test.dart
@@ -1,0 +1,99 @@
+// Tests for the GxEPD/Arduino export display presets.
+//
+// These lock in the data integrity of lib/util/epd/display_presets.dart,
+// which is the hardware preset list backing the "Arduino / GxEPD Export"
+// feature that addresses
+// https://github.com/fossasia/magic-epaper-app/issues/183.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magicepaperapp/theme/colors.dart';
+import 'package:magicepaperapp/util/epd/display_presets.dart';
+
+void main() {
+  group('displayPresets', () {
+    test('is not empty and always ends with the custom sentinel', () {
+      expect(displayPresets, isNotEmpty);
+      expect(displayPresets.last, same(DisplayPreset.custom));
+    });
+
+    test('every non-custom preset has positive dimensions', () {
+      for (final preset in displayPresets) {
+        if (preset == DisplayPreset.custom) continue;
+        expect(preset.width, greaterThan(0),
+            reason: '${preset.name} must have a positive width');
+        expect(preset.height, greaterThan(0),
+            reason: '${preset.name} must have a positive height');
+      }
+    });
+
+    test('every non-custom preset defines at least black and white', () {
+      for (final preset in displayPresets) {
+        if (preset == DisplayPreset.custom) continue;
+        expect(preset.colors.length, greaterThanOrEqualTo(2),
+            reason: '${preset.name} must have at least 2 colors');
+        expect(preset.colors, contains(colorWhite),
+            reason: '${preset.name} must include white');
+        expect(preset.colors, contains(colorBlack),
+            reason: '${preset.name} must include black');
+      }
+    });
+
+    test('every non-custom preset has a non-empty, unique name', () {
+      final names = <String>{};
+      for (final preset in displayPresets) {
+        if (preset == DisplayPreset.custom) continue;
+        expect(preset.name, isNotEmpty);
+        expect(names.add(preset.name), isTrue,
+            reason: 'Duplicate preset name: ${preset.name}');
+      }
+    });
+
+    test('DisplayPreset equality and hashing are based on name only', () {
+      final a = DisplayPreset(
+        name: 'Test Panel',
+        width: 100,
+        height: 100,
+        colors: const [Colors.white, Colors.black],
+      );
+      final b = DisplayPreset(
+        name: 'Test Panel',
+        width: 999,
+        height: 999,
+        colors: const [Colors.white],
+      );
+      final c = DisplayPreset(
+        name: 'Different Panel',
+        width: 100,
+        height: 100,
+        colors: const [Colors.white, Colors.black],
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('custom sentinel is a zero-size, colorless placeholder', () {
+      expect(DisplayPreset.custom.width, 0);
+      expect(DisplayPreset.custom.height, 0);
+      expect(DisplayPreset.custom.colors, isEmpty);
+    });
+
+    test('includes coverage for monochrome and multi-color panels', () {
+      final hasMonochrome =
+          displayPresets.any((p) => p != DisplayPreset.custom && p.colors.length == 2);
+      final hasThreeColor =
+          displayPresets.any((p) => p.colors.length == 3);
+      final hasMultiColor =
+          displayPresets.any((p) => p.colors.length > 3);
+
+      expect(hasMonochrome, isTrue,
+          reason: 'Expected at least one 2-color (B/W) preset');
+      expect(hasThreeColor, isTrue,
+          reason: 'Expected at least one 3-color (B/W/R) preset');
+      expect(hasMultiColor, isTrue,
+          reason: 'Expected at least one multi-color (Spectra-style) preset');
+    });
+  });
+}

--- a/test/xbm_encoder_test.dart
+++ b/test/xbm_encoder_test.dart
@@ -1,0 +1,94 @@
+// Tests for lib/util/xbm_encoder.dart, which produces the .xbm files
+// consumed by GxEPD2's drawXBitmap() in the "Arduino / GxEPD Export" flow
+// (see https://github.com/fossasia/magic-epaper-app/issues/183).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:magicepaperapp/util/xbm_encoder.dart';
+
+img.Image _blackWhiteImage(int width, int height, Set<int> blackXs) {
+  final image = img.Image(width: width, height: height, numChannels: 4);
+  for (var y = 0; y < height; y++) {
+    for (var x = 0; x < width; x++) {
+      if (blackXs.contains(x)) {
+        image.setPixelRgba(x, y, 0, 0, 0, 255);
+      } else {
+        image.setPixelRgba(x, y, 255, 255, 255, 255);
+      }
+    }
+  }
+  return image;
+}
+
+void main() {
+  group('XbmEncoder.encode', () {
+    test('writes width/height #define headers and array name', () {
+      final image = _blackWhiteImage(8, 1, {});
+      final result = XbmEncoder.encode(image, 'my_image');
+
+      expect(result, contains('#define my_image_width 8'));
+      expect(result, contains('#define my_image_height 1'));
+      expect(result, contains('static unsigned char my_image_bits[] = {'));
+      expect(result.trim(), endsWith('};'));
+    });
+
+    test('an all-white image encodes to all-zero bytes', () {
+      final image = _blackWhiteImage(8, 2, {});
+      final result = XbmEncoder.encode(image, 'blank');
+
+      expect(result, contains('0x00, 0x00,'));
+      expect(result, isNot(contains(RegExp(r'0x(?!00)'))));
+    });
+
+    test('sets bit 0 (LSB) for the leftmost pixel of a byte', () {
+      // XBM is LSB-first: the leftmost pixel in a byte maps to bit 0.
+      final image = _blackWhiteImage(8, 1, {0});
+      final result = XbmEncoder.encode(image, 'img');
+      expect(result, contains('0x01,'));
+    });
+
+    test('sets bit 7 (MSB) for the rightmost pixel of a full byte', () {
+      final image = _blackWhiteImage(8, 1, {7});
+      final result = XbmEncoder.encode(image, 'img');
+      expect(result, contains('0x80,'));
+    });
+
+    test('a fully black single byte row encodes to 0xff', () {
+      final image = _blackWhiteImage(8, 1, {0, 1, 2, 3, 4, 5, 6, 7});
+      final result = XbmEncoder.encode(image, 'img');
+      expect(result, contains('0xff,'));
+    });
+
+    test('pads the final partial byte of a non-multiple-of-8 width', () {
+      // width=3 -> 1 byte per row (rowStride = ceil(3/8) = 1), only the
+      // low 3 bits can ever be set; out-of-range bits (3..7) stay 0.
+      final allBlack = _blackWhiteImage(3, 1, {0, 1, 2});
+      final result = XbmEncoder.encode(allBlack, 'img');
+      // 0b0000_0111 = 0x07
+      expect(result, contains('0x07,'));
+    });
+
+    test('row stride is independent per row for multi-row images', () {
+      // 9px wide -> 2 bytes/row (ceil(9/8)=2). Row 0 all black, row 1 all white.
+      final image = img.Image(width: 9, height: 2, numChannels: 4);
+      for (var x = 0; x < 9; x++) {
+        image.setPixelRgba(x, 0, 0, 0, 0, 255);
+        image.setPixelRgba(x, 1, 255, 255, 255, 255);
+      }
+      final result = XbmEncoder.encode(image, 'img');
+
+      // Row 0: byte0 = 0xff (bits 0-7 set), byte1 = 0x01 (only bit0/x=8 set).
+      // Row 1: byte0 = 0x00, byte1 = 0x00.
+      expect(result, contains('0xff, 0x01,'));
+      expect(result, contains('0x00, 0x00,'));
+    });
+
+    test('treats any non-white pixel as foreground, not just pure black',
+        () {
+      final image = img.Image(width: 1, height: 1, numChannels: 4);
+      image.setPixelRgba(0, 0, 200, 0, 0, 255); // dark red, not pure black
+      final result = XbmEncoder.encode(image, 'img');
+      expect(result, contains('0x01,'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #<!-- Add issue number here. This will automatically close the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes
<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Optimize the Rust image dithering pipeline for higher throughput and efficiency.

New Features:
- Introduce specialized closest-color functions for black/white and black/white/red palettes to avoid generic palette distance computations.

Enhancements:
- Reuse static BLACK, WHITE, and RED color constants instead of per-call palette arrays.
- Precompute pixel count and reserve capacity for intermediate buffers to reduce allocations during image processing.
- Skip gamma LUT clamping by relying on the original 0–255 u8 range, simplifying and speeding up gamma correction.
- Construct the output RGBA image from a preallocated raw byte buffer instead of per-pixel put_pixel calls to speed up PNG encoding.
- Change error diffusion to operate on slices and use unchecked indexing after bounds checks for better performance.

Build:
- Tighten Rust release profile to use opt-level 3, enable LTO, reduce codegen units to 1, and switch to panic=abort for smaller and faster binaries.