### PR TITLE
fix: add max width constraint to image save dialog

### DIFF
--- a/lib/image_library/widgets/dialogs/image_save_dialog.dart
+++ b/lib/image_library/widgets/dialogs/image_save_dialog.dart
@@ -48,36 +48,41 @@ class _ImageSaveDialogState extends State<ImageSaveDialog> {
     return Dialog(
       backgroundColor: Colors.transparent,
       child: SingleChildScrollView(
-        child: Container(
-          padding: const EdgeInsets.all(Dimens.spacingXxl),
-          margin: const EdgeInsets.symmetric(vertical: 48),
-          decoration: BoxDecoration(
-            color: colorWhite,
-            borderRadius: BorderRadius.circular(Dimens.radiusRound),
-            boxShadow: [
-              BoxShadow(
-                color: colorBlack.withValues(alpha: 0.1),
-                blurRadius: 20,
-                offset: const Offset(0, 10),
-              ),
-            ],
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: Dimens.dialogMaxWidth,
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildHeader(),
-              const SizedBox(height: Dimens.spacingL),
-              _buildImagePreview(),
-              const SizedBox(height: Dimens.spacingL),
-              _buildTextFieldSection(),
-              const SizedBox(height: Dimens.spacingXxl),
-              if (widget.filterName != null) ...[
-                _buildFilterInfoChip(),
-                const SizedBox(height: Dimens.spacingXl),
+          child: Container(
+            padding: const EdgeInsets.all(Dimens.spacingXxl),
+            margin: const EdgeInsets.symmetric(vertical: 48),
+            decoration: BoxDecoration(
+              color: colorWhite,
+              borderRadius: BorderRadius.circular(Dimens.radiusRound),
+              boxShadow: [
+                BoxShadow(
+                  color: colorBlack.withValues(alpha: 0.1),
+                  blurRadius: 20,
+                  offset: const Offset(0, 10),
+                ),
               ],
-              _buildActionButtons(context),
-            ],
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildHeader(),
+                const SizedBox(height: Dimens.spacingL),
+                _buildImagePreview(),
+                const SizedBox(height: Dimens.spacingL),
+                _buildTextFieldSection(),
+                const SizedBox(height: Dimens.spacingXxl),
+                if (widget.filterName != null) ...[
+                  _buildFilterInfoChip(),
+                  const SizedBox(height: Dimens.spacingXl),
+                ],
+                _buildActionButtons(context),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Fixes #584

## Changes
add max width constraint to image save dialog

## Screenshots / Recordings

https://github.com/user-attachments/assets/1b7b3114-2efa-446e-860c-96ae7912dc84



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enhancements:
- Add a dialogMaxWidth constant to the Dimens configuration and apply it via a ConstrainedBox around the image save dialog content to prevent overly wide dialogs.