### PR TITLE
fix: add max width constraint to image rename dialog

### DIFF
--- a/lib/constants/dimens.dart
+++ b/lib/constants/dimens.dart
@@ -35,4 +35,6 @@ class Dimens {
 
   static const double borderWidthThin = 1.0;
   static const double borderWidthThick = 2.0;
+
+  static const double dialogMaxWidth = 550.0;
 }

--- a/lib/image_library/widgets/dialogs/image_rename_dialog.dart
+++ b/lib/image_library/widgets/dialogs/image_rename_dialog.dart
@@ -39,29 +39,34 @@ class _ImageRenameDialogState extends State<ImageRenameDialog> {
   Widget build(BuildContext context) {
     return Dialog(
       backgroundColor: Colors.transparent,
-      child: Container(
-        padding: const EdgeInsets.all(Dimens.spacingXxl),
-        decoration: BoxDecoration(
-          color: colorWhite,
-          borderRadius: BorderRadius.circular(Dimens.radiusRound),
-          boxShadow: [
-            BoxShadow(
-              color: colorBlack.withValues(alpha: 0.1),
-              blurRadius: 20,
-              offset: const Offset(0, 10),
-            ),
-          ],
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: Dimens.dialogMaxWidth,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildHeader(),
-            const SizedBox(height: Dimens.spacingXxl),
-            _buildTextFieldSection(context),
-            const SizedBox(height: Dimens.spacingXxxl),
-            _buildActionButtons(context),
-          ],
+        child: Container(
+          padding: const EdgeInsets.all(Dimens.spacingXxl),
+          decoration: BoxDecoration(
+            color: colorWhite,
+            borderRadius: BorderRadius.circular(Dimens.radiusRound),
+            boxShadow: [
+              BoxShadow(
+                color: colorBlack.withValues(alpha: 0.1),
+                blurRadius: 20,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(),
+              const SizedBox(height: Dimens.spacingXxl),
+              _buildTextFieldSection(context),
+              const SizedBox(height: Dimens.spacingXxxl),
+              _buildActionButtons(context),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Fixes #588

## Changes
add max width constraint to image rename dialog

## Screenshots / Recordings

https://github.com/user-attachments/assets/4a3ec5dc-bd72-47d8-8dca-8f23c838c147



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enhancements:
- Add a reusable dialogMaxWidth constant to standardize maximum widths of dialogs across the app.