### PR TITLE
fix: remove lint workaround 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -60,14 +60,6 @@ android {
         }
     }
 
-    // Workaround for: Execution failed for task ':image_picker_android:lintVitalAnalyzeRelease'
-    android {
-        lintOptions {
-            checkReleaseBuilds false
-            disable 'MissingTranslation'
-        }
-    }
-
 }
 
 kotlin {


### PR DESCRIPTION
Fixes #627

## Changes
Removes the lintOptions workaround from #621, no longer needed with image_picker 1.2.3.

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.