### PR TITLE
fix: scale image to display size before dithering  

### DIFF
--- a/lib/provider/image_loader.dart
+++ b/lib/provider/image_loader.dart
@@ -19,7 +19,11 @@ class ImageLoader extends ChangeNotifier {
     required int height,
   }) async {
     final ImagePicker picker = ImagePicker();
-    final XFile? file = await picker.pickImage(source: ImageSource.gallery);
+    final XFile? file = await picker.pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 3500,
+      maxHeight: 3500,
+    );
     if (file == null) return false;
 
     final bytes = await file.readAsBytes();

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -246,8 +246,13 @@ class _ImageEditorState extends State<ImageEditor> {
       flipVertical = false;
     });
 
+    final img.Image scaledSource = img.copyResize(
+      sourceImage,
+      width: widget.device.width,
+      height: widget.device.height,
+    );
     final Uint8List sourcePngBytes =
-        Uint8List.fromList(img.encodePng(sourceImage));
+        Uint8List.fromList(img.encodePng(scaledSource));
     final filtersToRun = widget.device.processingMethods;
 
     try {

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -229,7 +229,6 @@ class _ImageEditorState extends State<ImageEditor> {
     if (_processedSourceImage == sourceImage) {
       return;
     }
-    _pristineImage ??= img.Image.from(sourceImage);
     _processImagesAsync(sourceImage);
   }
 
@@ -245,6 +244,9 @@ class _ImageEditorState extends State<ImageEditor> {
       flipHorizontal = false;
       flipVertical = false;
     });
+
+    await Future.delayed(Duration.zero);
+    if (!mounted || _processedSourceImage != sourceImage) return;
 
     final img.Image scaledSource = img.copyResize(
       sourceImage,
@@ -262,7 +264,7 @@ class _ImageEditorState extends State<ImageEditor> {
         Uint8List bytesForRust = sourcePngBytes;
 
         if (filtersToRun[i].useDartHalftone) {
-          final tempImg = img.Image.from(sourceImage);
+          final tempImg = img.Image.from(scaledSource);
           if (filtersToRun[i].colorMode == rust_api.ColorMode.bw) {
             img.grayscale(tempImg);
           }

--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -246,7 +246,10 @@ class _ImageEditorState extends State<ImageEditor> {
     });
 
     await Future.delayed(Duration.zero);
-    if (!mounted || _processedSourceImage != sourceImage) return;
+    if (!mounted || _processedSourceImage != sourceImage) {
+      if (mounted) setState(() => _isProcessingImages = false);
+      return;
+    }
 
     final img.Image scaledSource = img.copyResize(
       sourceImage,


### PR DESCRIPTION
Fixes #630 

Large gallery photos (10–15 MB) took 15–18s to load and showed a black screen, because the full-resolution image was being processed before it was resized down.

## Changes
- Limit imported gallery images to a max of 3500×3500, so huge photos are shrunk at import instead of being processed at full size.                                              
- Resize the image to the display's dimensions before encoding and dithering, so heavy work runs on a small image.                                                               
- Run halftone filters on the already-resized image instead of the full-size one.                                                                                                
- Show the loading spinner immediately instead of a black screen while the first filter is generated.   
 
## Screenshots / Recordings

https://github.com/user-attachments/assets/7ed087e3-b428-4e26-90eb-bb6b0bc2a0dc



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Optimize gallery image processing by resizing large imports and images to display dimensions before filtering and dithering.

Bug Fixes:
- Reduce gallery image loading time and prevent the initial black screen by processing images at display resolution.

Enhancements:
- Limit imported gallery images to 3500×3500 and apply encoding and halftone processing after display-size scaling.
- Show processing state immediately while the initial image filter is generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Gallery image selection now limits images to 3500×3500 pixels.
  - Image processing is scaled to the device dimensions before encoding and applying visual effects, improving performance.
  - Prevented outdated or interrupted processing from replacing newer image results.
  - Improved image handling when opening color-adjustment controls, ensuring adjustments use the intended source image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->