### PR TITLE
fix: AGENTS.md flutter version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Guidance for AI coding agents (Claude Code, Cursor, Aider, Copilot, Codex, and o
 
 ## Tech Stack
 
-- **Framework**: Flutter (stable channel, pinned to `3.41.9` in `pubspec.yaml`)
+- **Framework**: Flutter (stable channel; check the `flutter` constraint in `pubspec.yaml` for the current pinned version)
 - **Language**: Dart (`>=3.3.4 <4.0.0`)
 - **State Management**: Provider pattern (`provider` package)
 - **Dependency Injection**: GetIt (service locator pattern)


### PR DESCRIPTION
Fixes #640

## Changes
Remove hardcoded Flutter version from AGENTS.md,direct agents to read it from pubspec.yaml instead.
## Screenshots / Recordings
  N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Remove the hardcoded Flutter version from AGENTS.md and reference pubspec.yaml as the source of truth.

Bug Fixes:
- Keep AGENTS.md aligned with the current Flutter version by directing agents to the version constraint in pubspec.yaml.

Documentation:
- Update AGENTS.md to avoid documenting a hardcoded Flutter version.