### PR TITLE
chore: add .fvm/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ linux/flutter/generated_plugin_registrant.cc
 linux/flutter/generated_plugins.cmake
 macos/Flutter/GeneratedPluginRegistrant.swift
 untranslated.json
+
+.fvm/


### PR DESCRIPTION
Fixes #646 

## Changes
 Keeps FVM's local version cache out of version control. 

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enhancements:
- Exclude FVM's local version cache from version control.