### PR TITLE
fix: guard setState in card template form finally blocks

### DIFF
--- a/lib/card_templates/employee_id_form.dart
+++ b/lib/card_templates/employee_id_form.dart
@@ -172,9 +172,11 @@ class _EmployeeIdFormState extends State<EmployeeIdForm> {
         _handleEditRequest(result);
       }
     } finally {
-      setState(() {
-        _isGenerating = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
     }
   }
 

--- a/lib/card_templates/price_tag_form.dart
+++ b/lib/card_templates/price_tag_form.dart
@@ -188,9 +188,11 @@ class _PriceTagFormState extends State<PriceTagForm> {
         _handleEditRequest(result);
       }
     } finally {
-      setState(() {
-        _isGenerating = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
     }
   }
 

--- a/test/card_templates/form_dispose_safety_test.dart
+++ b/test/card_templates/form_dispose_safety_test.dart
@@ -6,8 +6,6 @@ import 'package:magicepaperapp/card_templates/price_tag_form.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/color_palette_provider.dart';
 
-/// Records every route the navigator pushes so a test can remove one of them
-/// while another sits on top of it.
 class _RouteRecorder extends NavigatorObserver {
   final List<Route<dynamic>> pushed = <Route<dynamic>>[];
 
@@ -17,13 +15,6 @@ class _RouteRecorder extends NavigatorObserver {
   }
 }
 
-/// Reproduces the crash from issue #497: a card template form awaits the canvas
-/// editor route, and its `finally` block calls `setState()` when the editor
-/// returns. If the form was disposed while the editor was open, that call hits
-/// a defunct State and throws "setState() called after dispose()".
-///
-/// The `if (!mounted) return;` guard already present after the `await` does not
-/// prevent this — returning from a `try` still runs its `finally`.
 Future<void> _expectNoCrashWhenDisposedDuringEdit(
   WidgetTester tester, {
   required Widget form,
@@ -54,7 +45,6 @@ Future<void> _expectNoCrashWhenDisposedDuringEdit(
   await tester.tap(find.text('open form'));
   await tester.pumpAndSettle();
 
-  // The form's own route, which we will pull out from under the editor.
   final formRoute = recorder.pushed.last;
 
   final generateButton = find.text(generateLabel);
@@ -62,12 +52,9 @@ Future<void> _expectNoCrashWhenDisposedDuringEdit(
   await tester.tap(generateButton);
   await tester.pumpAndSettle();
 
-  // The canvas editor is now on top of the form.
   final editorRoute = recorder.pushed.last;
   expect(editorRoute, isNot(same(formRoute)));
 
-  // Dispose the form while the editor is still open, then close the editor.
-  // Completing the awaited push is what runs the form's `finally` block.
   final navigator = tester.state<NavigatorState>(find.byType(Navigator));
   navigator.removeRoute(formRoute);
   await tester.pumpAndSettle();

--- a/test/card_templates/form_dispose_safety_test.dart
+++ b/test/card_templates/form_dispose_safety_test.dart
@@ -20,6 +20,10 @@ Future<void> _expectNoCrashWhenDisposedDuringEdit(
   required Widget form,
   required String generateLabel,
 }) async {
+  tester.view.physicalSize = const Size(1080, 3200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
   final recorder = _RouteRecorder();
 
   await tester.pumpWidget(
@@ -48,7 +52,8 @@ Future<void> _expectNoCrashWhenDisposedDuringEdit(
   final formRoute = recorder.pushed.last;
 
   final generateButton = find.text(generateLabel);
-  await tester.scrollUntilVisible(generateButton, 200);
+  await tester.ensureVisible(generateButton);
+  await tester.pumpAndSettle();
   await tester.tap(generateButton);
   await tester.pumpAndSettle();
 

--- a/test/card_templates/form_dispose_safety_test.dart
+++ b/test/card_templates/form_dispose_safety_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:magicepaperapp/card_templates/employee_id_form.dart';
+import 'package:magicepaperapp/card_templates/price_tag_form.dart';
+import 'package:magicepaperapp/l10n/app_localizations.dart';
+import 'package:magicepaperapp/provider/color_palette_provider.dart';
+
+/// Records every route the navigator pushes so a test can remove one of them
+/// while another sits on top of it.
+class _RouteRecorder extends NavigatorObserver {
+  final List<Route<dynamic>> pushed = <Route<dynamic>>[];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushed.add(route);
+  }
+}
+
+/// Reproduces the crash from issue #497: a card template form awaits the canvas
+/// editor route, and its `finally` block calls `setState()` when the editor
+/// returns. If the form was disposed while the editor was open, that call hits
+/// a defunct State and throws "setState() called after dispose()".
+///
+/// The `if (!mounted) return;` guard already present after the `await` does not
+/// prevent this — returning from a `try` still runs its `finally`.
+Future<void> _expectNoCrashWhenDisposedDuringEdit(
+  WidgetTester tester, {
+  required Widget form,
+  required String generateLabel,
+}) async {
+  final recorder = _RouteRecorder();
+
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      navigatorObservers: <NavigatorObserver>[recorder],
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute<void>(builder: (_) => form),
+              ),
+              child: const Text('open form'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('open form'));
+  await tester.pumpAndSettle();
+
+  // The form's own route, which we will pull out from under the editor.
+  final formRoute = recorder.pushed.last;
+
+  final generateButton = find.text(generateLabel);
+  await tester.scrollUntilVisible(generateButton, 200);
+  await tester.tap(generateButton);
+  await tester.pumpAndSettle();
+
+  // The canvas editor is now on top of the form.
+  final editorRoute = recorder.pushed.last;
+  expect(editorRoute, isNot(same(formRoute)));
+
+  // Dispose the form while the editor is still open, then close the editor.
+  // Completing the awaited push is what runs the form's `finally` block.
+  final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+  navigator.removeRoute(formRoute);
+  await tester.pumpAndSettle();
+
+  navigator.pop();
+  await tester.pumpAndSettle();
+
+  expect(tester.takeException(), isNull);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppLocalizations l10n;
+
+  setUp(() async {
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    final getIt = GetIt.instance;
+    if (getIt.isRegistered<AppLocalizations>()) {
+      getIt.unregister<AppLocalizations>();
+    }
+    getIt.registerSingleton<AppLocalizations>(l10n);
+    if (!getIt.isRegistered<ColorPaletteProvider>()) {
+      getIt.registerLazySingleton<ColorPaletteProvider>(
+          () => ColorPaletteProvider());
+    }
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  group('card template forms survive disposal while the editor is open', () {
+    testWidgets('EmployeeIdForm', (tester) async {
+      await _expectNoCrashWhenDisposedDuringEdit(
+        tester,
+        form: const EmployeeIdForm(width: 296, height: 128),
+        generateLabel: l10n.generateIdCard,
+      );
+    });
+
+    testWidgets('PriceTagForm', (tester) async {
+      await _expectNoCrashWhenDisposedDuringEdit(
+        tester,
+        form: const PriceTagForm(width: 296, height: 128),
+        generateLabel: l10n.generatePriceTag,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #497

## Problem

`EmployeeIdForm._submitForm` and `PriceTagForm._submitForm` await the canvas editor route inside a `try`, and their `finally` block calls `setState()` unconditionally:

```dart
try {
  final result = await Navigator.of(context).push<Object>(...);
  if (!mounted) return;
  ...
} finally {
  setState(() {          // runs even when the widget is gone
    _isGenerating = false;
  });
}
```

Both forms already have the `if (!mounted) return;` guard the issue asks for, but it does not help here: in Dart, returning from a `try` still executes its `finally`. So when the form is disposed while the editor is open, the guard returns straight into a `setState()` on a defunct `State`, producing the reported `setState() called after dispose()`.

## Fix

Guard the `finally` block with a `mounted` check, matching the pattern the sibling forms already use (`event_badge_form`, `entry_pass_tag_form`, `contact_card_form`, `qr_tag_form`, `weather_form`, `restaurant_menu_form`):

```dart
} finally {
  if (mounted) {
    setState(() {
      _isGenerating = false;
    });
  }
}
```

## Scope note

The issue lists five affected files. I audited every awaited `Navigator.push` under `lib/` and only two of them are actually unsafe:

| File | Status |
| --- | --- |
| `employee_id_form.dart` | **fixed here** — unguarded `setState` in `finally` |
| `price_tag_form.dart` | **fixed here** — unguarded `setState` in `finally` |
| `card_template_selection_view.dart` | no bug — the `await` is the last statement in each of the 9 callbacks; nothing touches `context` or `setState` afterwards |
| `event_badge_form.dart` | already guarded |
| `entry_pass_tag_form.dart` | already guarded |
| `qr_tag_form.dart`, `contact_card_form.dart`, `weather_form.dart`, `restaurant_menu_form.dart` | already guarded (not listed in the issue) |
| `bulk/bulk_results_screen.dart`, `image_library.dart` | already guarded (not listed in the issue) |

## Tests

Adds `test/card_templates/form_dispose_safety_test.dart`, which pushes the form, opens the editor, removes the form's route from under it, then pops the editor — completing the awaited push and running the `finally` block against a disposed `State`. The test fails with `setState() called after dispose()` before the fix and passes after it.

## Summary by Sourcery

Guard card template form cleanup after asynchronous editor navigation to avoid setState calls on disposed widgets.

Bug Fixes:
- Prevent card template forms from calling setState after disposal when the editor route completes.

Tests:
- Add widget tests covering disposal of EmployeeIdForm and PriceTagForm while the editor is open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented errors when Employee ID and price tag forms are closed while an editor is opening or returning.
  - Improved stability during asynchronous navigation and widget disposal.
  - Ensured form state remains stable when the originating screen is no longer available.

- **Tests**
  - Added coverage for safely closing both forms while their editor routes are active.
  - Expanded reliability checks for navigation, disposal, and returning from the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->