### PR TITLE
fix: cancel image editor debounce timer on dispose

### DIFF
--- a/lib/view/image_editor.dart
+++ b/lib/view/image_editor.dart
@@ -114,6 +114,12 @@ class _ImageEditorState extends State<ImageEditor> {
     });
   }
 
+  @override
+  void dispose() {
+    _colorDebounce?.cancel();
+    super.dispose();
+  }
+
   Future<void> loadInitialImage() async {
     try {
       final imgLoader = context.read<ImageLoader>();


### PR DESCRIPTION
Fixes #652

## Problem

`_ImageEditorState` starts a 300 ms debounce `Timer` when the brightness/contrast sliders move, but the class had **no `dispose()` override at all**, so the timer was never cancelled.

Leaving the editor within 300 ms of the last slider movement lets the timer fire against a disposed `State`. It passes the `_pristineImage` null check and runs both `compute()` calls — spawning isolates to apply the adjustments and PNG-encode the result — before the existing `if (!mounted) return;` guard finally stops it.

There's no crash, since that guard catches it before `imgLoader.updateImage`. The cost is a leak: until the timer fires it keeps the `State`, the closure and `_pristineImage` (a full decoded image) alive, and two isolate computations run for a screen the user has already left.

## Fix

```dart
@override
void dispose() {
  _colorDebounce?.cancel();
  super.dispose();
}
```

## Notes

`_ImageEditorState` was the only `State` subclass in `lib/` holding a timer/controller-style field with no `dispose()` — I scanned the rest and they're all covered.

The other thing this class does in `initState` is `setPortraitOrientation()`, which is never restored. I left that alone deliberately: `about_us_screen`, `buy_badge_screen` and `settings_screen` all do the same, so it reads as an intentional app-wide portrait lock rather than a leak in this screen.

## Summary by Sourcery

Bug Fixes:
- Cancel the image editor’s pending color-adjustment debounce timer when the editor state is disposed, preventing unnecessary work and retained image state after leaving the screen.