### PR TITLE
fix: re-render stickers when canvas background color changes

### DIFF
--- a/lib/native_canvas/model/canvas_element.dart
+++ b/lib/native_canvas/model/canvas_element.dart
@@ -49,6 +49,7 @@ class CanvasElement {
   final Widget? child;
   final bool followCanvasTheme;
   final String? elementId;
+  final String? stickerIcon;
 
   const CanvasElement({
     required this.id,
@@ -71,6 +72,7 @@ class CanvasElement {
     this.child,
     this.followCanvasTheme = true,
     this.elementId,
+    this.stickerIcon,
   });
 
   CanvasElement copyWith({
@@ -112,6 +114,7 @@ class CanvasElement {
       child: child,
       followCanvasTheme: followCanvasTheme ?? this.followCanvasTheme,
       elementId: elementId,
+      stickerIcon: stickerIcon,
     );
   }
 
@@ -136,6 +139,7 @@ class CanvasElement {
       if (barcodeData != null) 'barcodeData': barcodeData,
       'followCanvasTheme': followCanvasTheme,
       if (elementId != null) 'elementId': elementId,
+      if (stickerIcon != null) 'stickerIcon': stickerIcon,
     };
   }
 
@@ -173,6 +177,7 @@ class CanvasElement {
       barcodeData: json['barcodeData'] as String?,
       followCanvasTheme: json['followCanvasTheme'] as bool? ?? true,
       elementId: json['elementId'] as String?,
+      stickerIcon: json['stickerIcon'] as String?,
     );
   }
 }

--- a/lib/native_canvas/native_canvas_editor.dart
+++ b/lib/native_canvas/native_canvas_editor.dart
@@ -18,6 +18,7 @@ import 'package:magicepaperapp/native_canvas/widgets/editable_element.dart';
 import 'package:magicepaperapp/native_canvas/widgets/stroke_painter.dart';
 import 'package:magicepaperapp/constants/color_constants.dart';
 import 'package:magicepaperapp/native_canvas/widgets/barcode_editor.dart';
+import 'package:magicepaperapp/native_canvas/sticker_vault/iconify_service.dart';
 import 'package:magicepaperapp/native_canvas/sticker_vault/sticker_vault_sheet.dart';
 import 'package:magicepaperapp/provider/color_palette_provider.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
@@ -760,12 +761,12 @@ class _NativeCanvasEditorState extends State<NativeCanvasEditor> {
 
   Future<void> _addSticker() async {
     _controller.select(null);
-    final bytes = await showStickerVault(context, inkColor: _inkColor);
-    if (bytes == null || !mounted) return;
-    _placeSticker(bytes);
+    final result = await showStickerVault(context, inkColor: _inkColor);
+    if (result == null || !mounted) return;
+    _placeSticker(result.bytes, stickerIcon: result.iconName);
   }
 
-  void _placeSticker(Uint8List bytes) {
+  void _placeSticker(Uint8List bytes, {String? stickerIcon}) {
     final decoded = img.decodeImage(bytes);
     final aspect = (decoded == null || decoded.height == 0)
         ? 1.0
@@ -786,8 +787,34 @@ class _NativeCanvasEditorState extends State<NativeCanvasEditor> {
         position: _nextSpawnPosition(),
         baseSize: Size(w, h),
         imageBytes: bytes,
+        stickerIcon: stickerIcon,
       ),
     );
+  }
+
+  Future<void> _cycleAndRerenderStickers() async {
+    _controller.cycleCanvasColor();
+    await _rerenderThemeStickers();
+  }
+
+  Future<void> _rerenderThemeStickers() async {
+    final inkColor = _controller.contrastColor(_controller.canvasColor);
+    final service = IconifyService();
+    try {
+      for (final e in _controller.elements) {
+        if (e.kind != CanvasElementKind.image) continue;
+        if (!e.followCanvasTheme) continue;
+        final icon = e.stickerIcon;
+        if (icon == null) continue;
+        try {
+          final bytes = await service.renderPng(icon, color: inkColor);
+          if (!mounted) return;
+          _controller.updateElement(e.copyWith(imageBytes: bytes));
+        } catch (_) {}
+      }
+    } finally {
+      service.dispose();
+    }
   }
 
   Future<void> _replaceImage(CanvasElement element) async {
@@ -1100,7 +1127,7 @@ class _NativeCanvasEditorState extends State<NativeCanvasEditor> {
           Expanded(
             child: _BarButton(
               label: appLocalizations.canvas,
-              onTap: _controller.cycleCanvasColor,
+              onTap: () => _cycleAndRerenderStickers(),
               iconWidget: Container(
                 width: 22,
                 height: 22,

--- a/lib/native_canvas/sticker_vault/sticker_vault_sheet.dart
+++ b/lib/native_canvas/sticker_vault/sticker_vault_sheet.dart
@@ -176,11 +176,13 @@ const List<_StickerCategory> _categories = [
   ]),
 ];
 
-Future<Uint8List?> showStickerVault(
+typedef StickerResult = ({Uint8List bytes, String iconName});
+
+Future<StickerResult?> showStickerVault(
   BuildContext context, {
   required Color inkColor,
 }) {
-  return showModalBottomSheet<Uint8List>(
+  return showModalBottomSheet<StickerResult>(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
@@ -293,7 +295,7 @@ class _StickerVaultSheetState extends State<_StickerVaultSheet> {
       final bytes = await _service.renderPng(iconName, color: widget.inkColor);
       await _recentsStore.add(iconName);
       if (!mounted) return;
-      Navigator.pop(context, bytes);
+      Navigator.pop(context, (bytes: bytes, iconName: iconName));
     } catch (e) {
       if (!mounted) return;
       setState(() => _placing = null);


### PR DESCRIPTION
Fixes #656 

## Changes
  - When you tap the Canvas button to cycle the background color, all stickers automatically re-render in the correct contrast color (same way text does)                          
## Screenshots / Recordings

https://github.com/user-attachments/assets/787e1aac-d16e-4d88-ab2b-56f0a333e78c


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Update canvas color changes to refresh theme-aware stickers alongside text for consistent contrast.

Bug Fixes:
- Re-render theme-aware stickers with the correct contrast color whenever the canvas background color changes.

Enhancements:
- Preserve sticker icon identifiers so selected stickers can be regenerated for updated canvas themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Selected sticker icons are now preserved with canvas elements.
  - Sticker selections retain their icon identity for consistent rendering.
  - Stickers that follow the selected theme automatically refresh when the canvas color changes.
  - Theme-following stickers update their contrast for improved visibility.
  - Changing the canvas color now refreshes applicable stickers automatically, keeping their appearance aligned with the selected theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->