### PR TITLE
fix: create temporary directory before saving cropped image

### DIFF
--- a/lib/card_templates/util/image_picker_util.dart
+++ b/lib/card_templates/util/image_picker_util.dart
@@ -21,6 +21,7 @@ Future<File?> pickAndEditImage(BuildContext context) async {
   if (cropped == null) return null;
 
   final dir = await getTemporaryDirectory();
+  await dir.create(recursive: true);
   final outFile = File(
     '${dir.path}/mep_crop_${DateTime.now().microsecondsSinceEpoch}.png',
   );


### PR DESCRIPTION
Fixes #659

## Changes
Create the temporary directory before writing the cropped image.


## Screenshots / Recordings

MacOS:

https://github.com/user-attachments/assets/7f7fd221-81f6-41e8-ab82-730baff73862


Android :

https://github.com/user-attachments/assets/9468dae0-2316-469f-97b2-311bccad6d56


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Ensure the temporary directory exists before saving cropped images, preventing failures when the directory has not yet been created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image editing reliability by ensuring the temporary directory is created before saving cropped images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->