### PR TITLE
fix: delete temporary profile images after card creation

### DIFF
--- a/lib/card_templates/contact_card_form.dart
+++ b/lib/card_templates/contact_card_form.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
@@ -11,6 +12,7 @@ import 'package:magicepaperapp/constants/dimens.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
 import 'package:magicepaperapp/native_canvas/native_canvas_editor.dart';
+import 'package:magicepaperapp/util/app_logger.dart';
 import 'package:magicepaperapp/util/page_route_util.dart';
 import 'package:magicepaperapp/card_templates/util/barcode_scanner_util.dart';
 import 'package:magicepaperapp/view/widget/common_scaffold_widget.dart';
@@ -54,6 +56,8 @@ class _ContactCardFormState extends State<ContactCardForm> {
   };
 
   File? _profileImage;
+  File? _ownedProfileImage;
+  int _imageSelectionGeneration = 0;
   bool _isGenerating = false;
   ContactQrMode _qrMode = ContactQrMode.vCard;
 
@@ -85,6 +89,10 @@ class _ContactCardFormState extends State<ContactCardForm> {
 
   @override
   void dispose() {
+    _imageSelectionGeneration++;
+    final ownedProfileImage = _ownedProfileImage;
+    _ownedProfileImage = null;
+    unawaited(_deleteTemporaryImage(ownedProfileImage));
     _fullNameController.removeListener(_updatePreview);
     _jobTitleController.removeListener(_updatePreview);
     _companyController.removeListener(_updatePreview);
@@ -103,6 +111,16 @@ class _ContactCardFormState extends State<ContactCardForm> {
       node.dispose();
     }
     super.dispose();
+  }
+
+  Future<void> _deleteTemporaryImage(File? image) async {
+    if (image == null) return;
+
+    try {
+      await image.delete();
+    } catch (e) {
+      AppLogger.error('Failed to delete temporary image: $e');
+    }
   }
 
   ContactCardModel _buildModel() {
@@ -125,11 +143,20 @@ class _ContactCardFormState extends State<ContactCardForm> {
   }
 
   Future<void> _pickImage() async {
+    final selectionGeneration = ++_imageSelectionGeneration;
     final picked = await pickAndEditImage(context);
-    if (picked != null && mounted) {
-      _profileImage = picked;
-      _updatePreview();
+    if (picked == null) return;
+
+    if (!mounted || selectionGeneration != _imageSelectionGeneration) {
+      unawaited(_deleteTemporaryImage(picked));
+      return;
     }
+
+    final previousOwnedImage = _ownedProfileImage;
+    _profileImage = picked;
+    _ownedProfileImage = picked;
+    unawaited(_deleteTemporaryImage(previousOwnedImage));
+    _updatePreview();
   }
 
   void _handleEditRequest(String elementId) {

--- a/lib/card_templates/employee_id_form.dart
+++ b/lib/card_templates/employee_id_form.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
@@ -10,6 +11,7 @@ import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
 import 'package:magicepaperapp/native_canvas/native_canvas_editor.dart';
 import 'package:magicepaperapp/card_templates/template_layer_builders.dart';
+import 'package:magicepaperapp/util/app_logger.dart';
 import 'package:magicepaperapp/card_templates/bulk/bulk_csv_import_screen.dart';
 import 'package:magicepaperapp/card_templates/bulk/bulk_template.dart';
 import 'package:magicepaperapp/util/epd/display_device.dart';
@@ -50,6 +52,8 @@ class _EmployeeIdFormState extends State<EmployeeIdForm> {
   };
 
   File? _profileImage;
+  File? _ownedProfileImage;
+  int _imageSelectionGeneration = 0;
   bool _isGenerating = false;
 
   late EmployeeIdModel _employeeData;
@@ -76,6 +80,10 @@ class _EmployeeIdFormState extends State<EmployeeIdForm> {
 
   @override
   void dispose() {
+    _imageSelectionGeneration++;
+    final ownedProfileImage = _ownedProfileImage;
+    _ownedProfileImage = null;
+    unawaited(_deleteTemporaryImage(ownedProfileImage));
     _companyNameController.removeListener(_updatePreview);
     _nameController.removeListener(_updatePreview);
     _idNumberController.removeListener(_updatePreview);
@@ -110,12 +118,31 @@ class _EmployeeIdFormState extends State<EmployeeIdForm> {
     });
   }
 
-  Future<void> _pickImage() async {
-    final picked = await pickAndEditImage(context);
-    if (picked != null && mounted) {
-      _profileImage = picked;
-      _updatePreview();
+  Future<void> _deleteTemporaryImage(File? image) async {
+    if (image == null) return;
+
+    try {
+      await image.delete();
+    } catch (e) {
+      AppLogger.error('Failed to delete temporary image: $e');
     }
+  }
+
+  Future<void> _pickImage() async {
+    final selectionGeneration = ++_imageSelectionGeneration;
+    final picked = await pickAndEditImage(context);
+    if (picked == null) return;
+
+    if (!mounted || selectionGeneration != _imageSelectionGeneration) {
+      unawaited(_deleteTemporaryImage(picked));
+      return;
+    }
+
+    final previousOwnedImage = _ownedProfileImage;
+    _profileImage = picked;
+    _ownedProfileImage = picked;
+    unawaited(_deleteTemporaryImage(previousOwnedImage));
+    _updatePreview();
   }
 
   void _handleEditRequest(String elementId) {

--- a/lib/card_templates/entry_pass_tag_form.dart
+++ b/lib/card_templates/entry_pass_tag_form.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
@@ -9,6 +10,7 @@ import 'package:magicepaperapp/constants/dimens.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
 import 'package:magicepaperapp/native_canvas/native_canvas_editor.dart';
+import 'package:magicepaperapp/util/app_logger.dart';
 import 'package:magicepaperapp/card_templates/template_layer_builders.dart';
 import 'package:magicepaperapp/card_templates/bulk/bulk_csv_import_screen.dart';
 import 'package:magicepaperapp/card_templates/bulk/bulk_template.dart';
@@ -48,6 +50,8 @@ class _EntryPassTagFormState extends State<EntryPassTagForm> {
   };
 
   File? _profileImage;
+  File? _ownedProfileImage;
+  int _imageSelectionGeneration = 0;
   bool _isGenerating = false;
 
   late EntryPassTagModel _passData;
@@ -75,6 +79,10 @@ class _EntryPassTagFormState extends State<EntryPassTagForm> {
   @override
   void dispose() {
     _venueNameController.removeListener(_updatePreview);
+    _imageSelectionGeneration++;
+    final ownedProfileImage = _ownedProfileImage;
+    _ownedProfileImage = null;
+    unawaited(_deleteTemporaryImage(ownedProfileImage));
     _visitorNameController.removeListener(_updatePreview);
     _passTypeController.removeListener(_updatePreview);
     _validDateController.removeListener(_updatePreview);
@@ -108,12 +116,31 @@ class _EntryPassTagFormState extends State<EntryPassTagForm> {
     });
   }
 
-  Future<void> _pickImage() async {
-    final picked = await pickAndEditImage(context);
-    if (picked != null && mounted) {
-      _profileImage = picked;
-      _updatePreview();
+  Future<void> _deleteTemporaryImage(File? image) async {
+    if (image == null) return;
+
+    try {
+      await image.delete();
+    } catch (e) {
+      AppLogger.error('Failed to delete temporary image: $e');
     }
+  }
+
+  Future<void> _pickImage() async {
+    final selectionGeneration = ++_imageSelectionGeneration;
+    final picked = await pickAndEditImage(context);
+    if (picked == null) return;
+
+    if (!mounted || selectionGeneration != _imageSelectionGeneration) {
+      unawaited(_deleteTemporaryImage(picked));
+      return;
+    }
+
+    final previousOwnedImage = _ownedProfileImage;
+    _profileImage = picked;
+    _ownedProfileImage = picked;
+    unawaited(_deleteTemporaryImage(previousOwnedImage));
+    _updatePreview();
   }
 
   Future<void> _scanQrData() async {

--- a/lib/card_templates/event_badge_form.dart
+++ b/lib/card_templates/event_badge_form.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
@@ -9,6 +10,7 @@ import 'package:magicepaperapp/constants/dimens.dart';
 import 'package:magicepaperapp/l10n/app_localizations.dart';
 import 'package:magicepaperapp/provider/getitlocator.dart';
 import 'package:magicepaperapp/native_canvas/native_canvas_editor.dart';
+import 'package:magicepaperapp/util/app_logger.dart';
 import 'package:magicepaperapp/card_templates/template_layer_builders.dart';
 import 'package:magicepaperapp/card_templates/bulk/bulk_csv_import_screen.dart';
 import 'package:magicepaperapp/card_templates/bulk/bulk_template.dart';
@@ -49,6 +51,8 @@ class _EventBadgeFormState extends State<EventBadgeForm> {
   };
 
   File? _profileImage;
+  File? _ownedProfileImage;
+  int _imageSelectionGeneration = 0;
   bool _isGenerating = false;
 
   late EventBadgeModel _badgeData;
@@ -76,6 +80,10 @@ class _EventBadgeFormState extends State<EventBadgeForm> {
   @override
   void dispose() {
     _eventNameController.removeListener(_updatePreview);
+    _imageSelectionGeneration++;
+    final ownedProfileImage = _ownedProfileImage;
+    _ownedProfileImage = null;
+    unawaited(_deleteTemporaryImage(ownedProfileImage));
     _attendeeNameController.removeListener(_updatePreview);
     _roleController.removeListener(_updatePreview);
     _organizationController.removeListener(_updatePreview);
@@ -109,12 +117,31 @@ class _EventBadgeFormState extends State<EventBadgeForm> {
     });
   }
 
-  Future<void> _pickImage() async {
-    final picked = await pickAndEditImage(context);
-    if (picked != null && mounted) {
-      _profileImage = picked;
-      _updatePreview();
+  Future<void> _deleteTemporaryImage(File? image) async {
+    if (image == null) return;
+
+    try {
+      await image.delete();
+    } catch (e) {
+      AppLogger.error('Failed to delete temporary image: $e');
     }
+  }
+
+  Future<void> _pickImage() async {
+    final selectionGeneration = ++_imageSelectionGeneration;
+    final picked = await pickAndEditImage(context);
+    if (picked == null) return;
+
+    if (!mounted || selectionGeneration != _imageSelectionGeneration) {
+      unawaited(_deleteTemporaryImage(picked));
+      return;
+    }
+
+    final previousOwnedImage = _ownedProfileImage;
+    _profileImage = picked;
+    _ownedProfileImage = picked;
+    unawaited(_deleteTemporaryImage(previousOwnedImage));
+    _updatePreview();
   }
 
   void _handleEditRequest(String elementId) {


### PR DESCRIPTION
Fixes #662

## Changes
- Added cleanup for temporary profile images created by Card Templates.

## Screenshots / Recordings




https://github.com/user-attachments/assets/e66580ea-5379-4af7-828c-5fb9b63bd00e






**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Clean up temporary profile images created during card template editing.

Bug Fixes:
- Delete temporary profile images when they are replaced, when the card template form is disposed, or when an outdated image selection completes.

Enhancements:
- Track image ownership and selection generations across contact cards, employee IDs, entry passes, and event badges to prevent stale temporary files from accumulating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved temporary profile image handling across contact cards, employee IDs, entry pass tags, and event badges.
  - Prevented outdated image selections from replacing newer choices.
  - Automatically cleans up temporary images when replaced or when forms are closed.
  - Improved handling and logging of image cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->